### PR TITLE
MOVE文の部分参照の境界チェックバグを修正

### DIFF
--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -5978,6 +5978,13 @@ cb_build_move (cb_tree src, cb_tree dst)
 		}
 	}
 
+	if (CB_EXCEPTION_ENABLE (COB_EC_BOUND_REF_MOD)) {
+		if ((CB_REFERENCE_P (src) && CB_REFERENCE (src)->offset != NULL) ||
+		    (CB_REFERENCE_P (dst) && CB_REFERENCE (dst)->offset != NULL)) {
+			return cb_build_move_call (src, dst);
+		}	
+	}
+
 	/* output optimal code */
 	if (src == cb_zero) {
 		return cb_build_move_zero (dst);

--- a/tests/run
+++ b/tests/run
@@ -303,7 +303,7 @@ at_times_file=$at_suite_dir/at-times
 # List of the tested programs.
 at_tested='cobc'
 # List of the all the test groups.
-at_groups_all=' 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199'
+at_groups_all=' 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203'
 # As many dots as there are digits in the last test group number.
 # Used to normalize the test group numbers so that `ls' lists them in
 # numerical order.
@@ -326,188 +326,192 @@ at_help_all='1;fundamental.at:23;DISPLAY literals;;
 15;subscripts.at:215;Subscript bounds with ODO (upper);;
 16;subscripts.at:238;Subscript bounds with ODO;;
 17;subscripts.at:264;Subscript by arithmetic expression;;
-18;ref-mod.at:35;Separate sign positions;;
-19;ref-mod.at:60;Static reference modification;;
-20;ref-mod.at:90;Dynamic reference modification;;
-21;ref-mod.at:121;Static out of bounds;;
-22;ref-mod.at:150;Offset underflow;;
-23;ref-mod.at:172;Offset overflow;;
-24;ref-mod.at:194;Length underflow;;
-25;ref-mod.at:216;Length overflow;;
-26;accept.at:23;ACCEPT;;
-27;initialize.at:27;INITIALIZE group entry with OCCURS;;
-28;initialize.at:52;INITIALIZE OCCURS with numeric edited;;
-29;initialize.at:75;INITIALIZE complex group (1);;
-30;initialize.at:99;INITIALIZE complex group (2);;
-31;initialize.at:123;INITIALIZE with REDEFINES;;
-32;misc.at:21;Source file not found;;
-33;misc.at:30;Comma separator without space;;
-34;misc.at:47;LOCAL-STORAGE;;
-35;misc.at:89;EXTERNAL data item;;
-36;misc.at:131;EXTERNAL AS data item;;
-37;misc.at:177;cobcrun validation;;
-38;misc.at:221;MOVE to itself;;
-39;misc.at:241;MOVE with refmod;;
-40;misc.at:261;MOVE with refmod (variable);;
-41;misc.at:283;MOVE with group refmod;;
-42;misc.at:304;MOVE indexes;;
-43;misc.at:326;MOVE X'00';;
-44;misc.at:361;Level 01 subscripts;;
-45;misc.at:382;Class check with reference modification;;
-46;misc.at:403;Index and parenthesized expression;;
-47;misc.at:423;String concatenation;;
-48;misc.at:457;Alphanumeric and binary numeric;;
-49;misc.at:481;Dynamic call with static linking;;
-50;misc.at:506;CALL m1. CALL m2. CALL m1.;;
-51;misc.at:559;CALL binary literal parameter/LENGTH OF;;
-52;misc.at:614;INSPECT REPLACING LEADING ZEROS BY SPACES;;
-53;misc.at:634;INSPECT: No repeat conversion check;;
-54;misc.at:655;INSPECT CONVERTING spaces;;
-55;misc.at:676;INSPECT CONVERTING different length;;
-56;misc.at:698;INSPECT: REPLACING figurative constant;;
-57;misc.at:719;INSPECT: TALLYING BEFORE;;
-58;misc.at:749;INSPECT: TALLYING AFTER;;
-59;misc.at:778;INSPECT REPLACING TRAILING ZEROS BY SPACES;;
-60;misc.at:798;INSPECT REPLACING complex;;
-61;misc.at:820;SWITCHES;;
-62;misc.at:878;Nested PERFORM;;
-63;misc.at:903;EXIT PERFORM;;
-64;misc.at:927;EXIT PERFORM CYCLE;;
-65;misc.at:951;EXIT PARAGRAPH;;
-66;misc.at:982;EXIT SECTION;;
-67;misc.at:1016;88 with FILLER;;
-68;misc.at:1043;Non-overflow after overflow;;
-69;misc.at:1070;PERFORM ... CONTINUE;;
-70;misc.at:1086;STRING with subscript reference;;
-71;misc.at:1109;UNSTRING DELIMITED ALL LOW-VALUE;;
-72;misc.at:1142;READ INTO AT-END sequence;;
-73;misc.at:1176;First READ on empty SEQUENTIAL INDEXED file;;
-74;misc.at:1213;REWRITE a RELATIVE file with RANDOM access;;
-75;misc.at:1267;SORT: table sort;;
-76;misc.at:1304;SORT: EBCDIC table sort;;
-77;misc.at:1348;SORT nonexistent file;;
-78;misc.at:1382;PIC ZZZ-, ZZZ+;;
-79;misc.at:1420;Larger REDEFINES lengths;;
-80;misc.at:1460;PERFORM type OSVS;;
-81;misc.at:1501;Sticky LINKAGE;;
-82;misc.at:1551;COB_PRE_LOAD test;;
-83;misc.at:1575;COB_LOAD_CASE=UPPER test;;
-84;misc.at:1599;88 level with FALSE IS clause;;
-85;misc.at:1624;ALLOCATE/FREE with BASED item;;
-86;misc.at:1648;INITIZIALIZE with reference modification;;
-87;misc.at:1671;CALL with OMITTED parameter;;
-88;misc.at:1709;ANY LENGTH;;
-89;misc.at:1749;READ - KEY ignored with sequential READ;;
-90;misc.at:1782;SORT - missing fcd in variable-length WRITE;;
-91;misc.at:1869;READ - missing fcd in variable-length WRITE;;
-92;extensions.at:24;COMP-5;;
-93;extensions.at:71;Hexadecimal numeric literal;;
-94;extensions.at:99;Semi-parenthesized condition;;
-95;extensions.at:120;ADDRESS OF;;
-96;extensions.at:183;LENGTH OF;;
-97;extensions.at:217;WHEN-COMPILED;;
-98;extensions.at:240;Complex OCCURS DEPENDING ON;;
-99;extensions.at:268;MOVE NON-INTEGER TO ALPHA-NUMERIC;;
-100;extensions.at:359;CALL USING file-name;;
-101;extensions.at:401;CALL unusual PROGRAM-ID.;;
-102;extensions.at:464;Case independent PROGRAM-ID;;
-103;extensions.at:487;PROGRAM-ID AS clause;;
-104;extensions.at:510;Quoted PROGRAM-ID;;
-105;extensions.at:535;ASSIGN MF;;
-106;extensions.at:567;ASSIGN IBM;;
-107;extensions.at:597;ASSIGN mapping;;
-108;extensions.at:633;ASSIGN expansion;;
-109;extensions.at:663;ASSIGN with COB_FILE_PATH;;
-110;extensions.at:696;NUMBER-OF-CALL-PARAMETERS;;
-111;extensions.at:752;PROCEDURE DIVISION USING BY ...;;
-112;extensions.at:801;PROCEDURE DIVISION CHAINING ...;;
-113;extensions.at:829;STOP RUN RETURNING;;
-114;extensions.at:846;ENTRY;;
-115;extensions.at:892;LINE SEQUENTIAL write;;
-116;extensions.at:933;LINE SEQUENTIAL read;;
-117;extensions.at:993;ASSIGN to KEYBOARD/DISPLAY;;
-118;extensions.at:1049;Environment/Argument variable;;
-119;extensions.at:1094;DECIMAL-POINT is COMMA (1);;
-120;extensions.at:1120;DECIMAL-POINT is COMMA (2);;
-121;extensions.at:1146;DECIMAL-POINT is COMMA (3);;
-122;extensions.at:1172;DECIMAL-POINT is COMMA (4);;
-123;extensions.at:1198;DECIMAL-POINT is COMMA (5);;
-124;extensions.at:1230;78 Level (1);;
-125;extensions.at:1251;78 Level (2);;
-126;extensions.at:1275;78 Level (3);;
-127;extensions.at:1297;Unreachable statement;;
-128;return-code.at:23;RETURN-CODE moving;;
-129;return-code.at:46;RETURN-CODE passing;;
-130;return-code.at:89;RETURN-CODE nested;;
-131;functions.at:22;FUNCTION ABS;;
-132;functions.at:43;FUNCTION ACOS;;
-133;functions.at:72;FUNCTION ANNUITY;;
-134;functions.at:102;FUNCTION ASIN;;
-135;functions.at:131;FUNCTION ATAN;;
-136;functions.at:160;FUNCTION CHAR;;
-137;functions.at:181;FUNCTION COMBINED-DATETIME;;
-138;functions.at:201;FUNCTION CONCATENATE;;
-139;functions.at:223;FUNCTION CONCATENATE with reference modding;;
-140;functions.at:246;FUNCTION COS;;
-141;functions.at:275;FUNCTION DATE-OF-INTEGER;;
-142;functions.at:295;FUNCTION DATE-TO-YYYYMMDD;;
-143;functions.at:315;FUNCTION DAY-OF-INTEGER;;
-144;functions.at:335;FUNCTION DAY-TO-YYYYDDD;;
-145;functions.at:355;FUNCTION E;;
-146;functions.at:375;FUNCTION EXCEPTION-FILE;;
-147;functions.at:405;FUNCTION EXCEPTION-LOCATION;;
-148;functions.at:439;FUNCTION EXCEPTION-STATEMENT;;
-149;functions.at:469;FUNCTION EXCEPTION-STATUS;;
-150;functions.at:499;FUNCTION EXP;;
-151;functions.at:527;FUNCTION FACTORIAL;;
-152;functions.at:547;FUNCTION FRACTION-PART;;
-153;functions.at:570;FUNCTION INTEGER;;
-154;functions.at:591;FUNCTION INTEGER-OF-DATE;;
-155;functions.at:611;FUNCTION INTEGER-OF-DAY;;
-156;functions.at:631;FUNCTION INTEGER-PART;;
-157;functions.at:652;FUNCTION LENGTH;;
-158;functions.at:673;FUNCTION LOCALE-DATE;;
-159;functions.at:697;FUNCTION LOCALE-TIME;;
-160;functions.at:721;FUNCTION LOCALE-TIME-FROM-SECONDS;;
-161;functions.at:745;FUNCTION LOG;;
-162;functions.at:774;FUNCTION LOG10;;
-163;functions.at:803;FUNCTION LOWER-CASE;;
-164;functions.at:824;FUNCTION LOWER-CASE with reference modding;;
-165;functions.at:845;FUNCTION MAX;;
-166;functions.at:865;FUNCTION MEAN;;
-167;functions.at:885;FUNCTION MEDIAN;;
-168;functions.at:905;FUNCTION MIDRANGE;;
-169;functions.at:925;FUNCTION MIN;;
-170;functions.at:945;FUNCTION MOD;;
-171;functions.at:965;FUNCTION NUMVAL;;
-172;functions.at:986;FUNCTION NUMVAL-C;;
-173;functions.at:1007;FUNCTION ORD;;
-174;functions.at:1027;FUNCTION ORD-MAX;;
-175;functions.at:1047;FUNCTION ORD-MIN;;
-176;functions.at:1067;FUNCTION PI;;
-177;functions.at:1087;FUNCTION PRESENT-VALUE;;
-178;functions.at:1107;FUNCTION RANGE;;
-179;functions.at:1127;FUNCTION REM;;
-180;functions.at:1147;FUNCTION REVERSE;;
-181;functions.at:1168;FUNCTION REVERSE with reference modding;;
-182;functions.at:1189;FUNCTION SECONDS-FROM-FORMATTED-TIME;;
-183;functions.at:1218;FUNCTION SECONDS-PAST-MIDNIGHT;;
-184;functions.at:1245;FUNCTION SIGN;;
-185;functions.at:1274;FUNCTION SIN;;
-186;functions.at:1303;FUNCTION SQRT;;
-187;functions.at:1332;FUNCTION STANDARD-DEVIATION;;
-188;functions.at:1360;FUNCTION STORED-CHAR-LENGTH;;
-189;functions.at:1382;FUNCTION SUBSTITUTE;;
-190;functions.at:1404;FUNCTION SUBSTITUTE with reference modding;;
-191;functions.at:1427;FUNCTION SUBSTITUTE-CASE;;
-192;functions.at:1449;FUNCTION SUBSTITUTE-CASE with reference mod;;
-193;functions.at:1472;FUNCTION TAN;;
-194;functions.at:1501;FUNCTION TRIM;;
-195;functions.at:1525;FUNCTION TRIM with reference modding;;
-196;functions.at:1549;FUNCTION UPPER-CASE;;
-197;functions.at:1570;FUNCTION UPPER-CASE with reference modding;;
-198;functions.at:1591;FUNCTION VARIANCE;;
-199;functions.at:1611;FUNCTION WHEN-COMPILED;;
+18;subscripts.at:287;Subscript out of bounds in MOVE (1);;
+19;subscripts.at:311;Subscript out of bounds in MOVE (2);;
+20;ref-mod.at:35;Separate sign positions;;
+21;ref-mod.at:60;Static reference modification;;
+22;ref-mod.at:90;Dynamic reference modification;;
+23;ref-mod.at:121;Static out of bounds;;
+24;ref-mod.at:150;Offset underflow;;
+25;ref-mod.at:172;Offset overflow;;
+26;ref-mod.at:194;Length underflow;;
+27;ref-mod.at:216;Length overflow;;
+28;ref-mod.at:241;Offset out of bounds in MOVE (1);;
+29;ref-mod.at:264;Offset out of bounds in MOVE (2);;
+30;accept.at:23;ACCEPT;;
+31;initialize.at:27;INITIALIZE group entry with OCCURS;;
+32;initialize.at:52;INITIALIZE OCCURS with numeric edited;;
+33;initialize.at:75;INITIALIZE complex group (1);;
+34;initialize.at:99;INITIALIZE complex group (2);;
+35;initialize.at:123;INITIALIZE with REDEFINES;;
+36;misc.at:21;Source file not found;;
+37;misc.at:30;Comma separator without space;;
+38;misc.at:47;LOCAL-STORAGE;;
+39;misc.at:89;EXTERNAL data item;;
+40;misc.at:131;EXTERNAL AS data item;;
+41;misc.at:177;cobcrun validation;;
+42;misc.at:221;MOVE to itself;;
+43;misc.at:241;MOVE with refmod;;
+44;misc.at:261;MOVE with refmod (variable);;
+45;misc.at:283;MOVE with group refmod;;
+46;misc.at:304;MOVE indexes;;
+47;misc.at:326;MOVE X'00';;
+48;misc.at:361;Level 01 subscripts;;
+49;misc.at:382;Class check with reference modification;;
+50;misc.at:403;Index and parenthesized expression;;
+51;misc.at:423;String concatenation;;
+52;misc.at:457;Alphanumeric and binary numeric;;
+53;misc.at:481;Dynamic call with static linking;;
+54;misc.at:506;CALL m1. CALL m2. CALL m1.;;
+55;misc.at:559;CALL binary literal parameter/LENGTH OF;;
+56;misc.at:614;INSPECT REPLACING LEADING ZEROS BY SPACES;;
+57;misc.at:634;INSPECT: No repeat conversion check;;
+58;misc.at:655;INSPECT CONVERTING spaces;;
+59;misc.at:676;INSPECT CONVERTING different length;;
+60;misc.at:698;INSPECT: REPLACING figurative constant;;
+61;misc.at:719;INSPECT: TALLYING BEFORE;;
+62;misc.at:749;INSPECT: TALLYING AFTER;;
+63;misc.at:778;INSPECT REPLACING TRAILING ZEROS BY SPACES;;
+64;misc.at:798;INSPECT REPLACING complex;;
+65;misc.at:820;SWITCHES;;
+66;misc.at:878;Nested PERFORM;;
+67;misc.at:903;EXIT PERFORM;;
+68;misc.at:927;EXIT PERFORM CYCLE;;
+69;misc.at:951;EXIT PARAGRAPH;;
+70;misc.at:982;EXIT SECTION;;
+71;misc.at:1016;88 with FILLER;;
+72;misc.at:1043;Non-overflow after overflow;;
+73;misc.at:1070;PERFORM ... CONTINUE;;
+74;misc.at:1086;STRING with subscript reference;;
+75;misc.at:1109;UNSTRING DELIMITED ALL LOW-VALUE;;
+76;misc.at:1142;READ INTO AT-END sequence;;
+77;misc.at:1176;First READ on empty SEQUENTIAL INDEXED file;;
+78;misc.at:1213;REWRITE a RELATIVE file with RANDOM access;;
+79;misc.at:1267;SORT: table sort;;
+80;misc.at:1304;SORT: EBCDIC table sort;;
+81;misc.at:1348;SORT nonexistent file;;
+82;misc.at:1382;PIC ZZZ-, ZZZ+;;
+83;misc.at:1420;Larger REDEFINES lengths;;
+84;misc.at:1460;PERFORM type OSVS;;
+85;misc.at:1501;Sticky LINKAGE;;
+86;misc.at:1551;COB_PRE_LOAD test;;
+87;misc.at:1575;COB_LOAD_CASE=UPPER test;;
+88;misc.at:1599;88 level with FALSE IS clause;;
+89;misc.at:1624;ALLOCATE/FREE with BASED item;;
+90;misc.at:1648;INITIZIALIZE with reference modification;;
+91;misc.at:1671;CALL with OMITTED parameter;;
+92;misc.at:1709;ANY LENGTH;;
+93;misc.at:1749;READ - KEY ignored with sequential READ;;
+94;misc.at:1782;SORT - missing fcd in variable-length WRITE;;
+95;misc.at:1869;READ - missing fcd in variable-length WRITE;;
+96;extensions.at:24;COMP-5;;
+97;extensions.at:71;Hexadecimal numeric literal;;
+98;extensions.at:99;Semi-parenthesized condition;;
+99;extensions.at:120;ADDRESS OF;;
+100;extensions.at:183;LENGTH OF;;
+101;extensions.at:217;WHEN-COMPILED;;
+102;extensions.at:240;Complex OCCURS DEPENDING ON;;
+103;extensions.at:268;MOVE NON-INTEGER TO ALPHA-NUMERIC;;
+104;extensions.at:359;CALL USING file-name;;
+105;extensions.at:401;CALL unusual PROGRAM-ID.;;
+106;extensions.at:464;Case independent PROGRAM-ID;;
+107;extensions.at:487;PROGRAM-ID AS clause;;
+108;extensions.at:510;Quoted PROGRAM-ID;;
+109;extensions.at:535;ASSIGN MF;;
+110;extensions.at:567;ASSIGN IBM;;
+111;extensions.at:597;ASSIGN mapping;;
+112;extensions.at:633;ASSIGN expansion;;
+113;extensions.at:663;ASSIGN with COB_FILE_PATH;;
+114;extensions.at:696;NUMBER-OF-CALL-PARAMETERS;;
+115;extensions.at:752;PROCEDURE DIVISION USING BY ...;;
+116;extensions.at:801;PROCEDURE DIVISION CHAINING ...;;
+117;extensions.at:829;STOP RUN RETURNING;;
+118;extensions.at:846;ENTRY;;
+119;extensions.at:892;LINE SEQUENTIAL write;;
+120;extensions.at:933;LINE SEQUENTIAL read;;
+121;extensions.at:993;ASSIGN to KEYBOARD/DISPLAY;;
+122;extensions.at:1049;Environment/Argument variable;;
+123;extensions.at:1094;DECIMAL-POINT is COMMA (1);;
+124;extensions.at:1120;DECIMAL-POINT is COMMA (2);;
+125;extensions.at:1146;DECIMAL-POINT is COMMA (3);;
+126;extensions.at:1172;DECIMAL-POINT is COMMA (4);;
+127;extensions.at:1198;DECIMAL-POINT is COMMA (5);;
+128;extensions.at:1230;78 Level (1);;
+129;extensions.at:1251;78 Level (2);;
+130;extensions.at:1275;78 Level (3);;
+131;extensions.at:1297;Unreachable statement;;
+132;return-code.at:23;RETURN-CODE moving;;
+133;return-code.at:46;RETURN-CODE passing;;
+134;return-code.at:89;RETURN-CODE nested;;
+135;functions.at:22;FUNCTION ABS;;
+136;functions.at:43;FUNCTION ACOS;;
+137;functions.at:72;FUNCTION ANNUITY;;
+138;functions.at:102;FUNCTION ASIN;;
+139;functions.at:131;FUNCTION ATAN;;
+140;functions.at:160;FUNCTION CHAR;;
+141;functions.at:181;FUNCTION COMBINED-DATETIME;;
+142;functions.at:201;FUNCTION CONCATENATE;;
+143;functions.at:223;FUNCTION CONCATENATE with reference modding;;
+144;functions.at:246;FUNCTION COS;;
+145;functions.at:275;FUNCTION DATE-OF-INTEGER;;
+146;functions.at:295;FUNCTION DATE-TO-YYYYMMDD;;
+147;functions.at:315;FUNCTION DAY-OF-INTEGER;;
+148;functions.at:335;FUNCTION DAY-TO-YYYYDDD;;
+149;functions.at:355;FUNCTION E;;
+150;functions.at:375;FUNCTION EXCEPTION-FILE;;
+151;functions.at:405;FUNCTION EXCEPTION-LOCATION;;
+152;functions.at:439;FUNCTION EXCEPTION-STATEMENT;;
+153;functions.at:469;FUNCTION EXCEPTION-STATUS;;
+154;functions.at:499;FUNCTION EXP;;
+155;functions.at:527;FUNCTION FACTORIAL;;
+156;functions.at:547;FUNCTION FRACTION-PART;;
+157;functions.at:570;FUNCTION INTEGER;;
+158;functions.at:591;FUNCTION INTEGER-OF-DATE;;
+159;functions.at:611;FUNCTION INTEGER-OF-DAY;;
+160;functions.at:631;FUNCTION INTEGER-PART;;
+161;functions.at:652;FUNCTION LENGTH;;
+162;functions.at:673;FUNCTION LOCALE-DATE;;
+163;functions.at:697;FUNCTION LOCALE-TIME;;
+164;functions.at:721;FUNCTION LOCALE-TIME-FROM-SECONDS;;
+165;functions.at:745;FUNCTION LOG;;
+166;functions.at:774;FUNCTION LOG10;;
+167;functions.at:803;FUNCTION LOWER-CASE;;
+168;functions.at:824;FUNCTION LOWER-CASE with reference modding;;
+169;functions.at:845;FUNCTION MAX;;
+170;functions.at:865;FUNCTION MEAN;;
+171;functions.at:885;FUNCTION MEDIAN;;
+172;functions.at:905;FUNCTION MIDRANGE;;
+173;functions.at:925;FUNCTION MIN;;
+174;functions.at:945;FUNCTION MOD;;
+175;functions.at:965;FUNCTION NUMVAL;;
+176;functions.at:986;FUNCTION NUMVAL-C;;
+177;functions.at:1007;FUNCTION ORD;;
+178;functions.at:1027;FUNCTION ORD-MAX;;
+179;functions.at:1047;FUNCTION ORD-MIN;;
+180;functions.at:1067;FUNCTION PI;;
+181;functions.at:1087;FUNCTION PRESENT-VALUE;;
+182;functions.at:1107;FUNCTION RANGE;;
+183;functions.at:1127;FUNCTION REM;;
+184;functions.at:1147;FUNCTION REVERSE;;
+185;functions.at:1168;FUNCTION REVERSE with reference modding;;
+186;functions.at:1189;FUNCTION SECONDS-FROM-FORMATTED-TIME;;
+187;functions.at:1218;FUNCTION SECONDS-PAST-MIDNIGHT;;
+188;functions.at:1245;FUNCTION SIGN;;
+189;functions.at:1274;FUNCTION SIN;;
+190;functions.at:1303;FUNCTION SQRT;;
+191;functions.at:1332;FUNCTION STANDARD-DEVIATION;;
+192;functions.at:1360;FUNCTION STORED-CHAR-LENGTH;;
+193;functions.at:1382;FUNCTION SUBSTITUTE;;
+194;functions.at:1404;FUNCTION SUBSTITUTE with reference modding;;
+195;functions.at:1427;FUNCTION SUBSTITUTE-CASE;;
+196;functions.at:1449;FUNCTION SUBSTITUTE-CASE with reference mod;;
+197;functions.at:1472;FUNCTION TAN;;
+198;functions.at:1501;FUNCTION TRIM;;
+199;functions.at:1525;FUNCTION TRIM with reference modding;;
+200;functions.at:1549;FUNCTION UPPER-CASE;;
+201;functions.at:1570;FUNCTION UPPER-CASE with reference modding;;
+202;functions.at:1591;FUNCTION VARIANCE;;
+203;functions.at:1611;FUNCTION WHEN-COMPILED;;
 '
 
 at_keywords=
@@ -2468,13 +2472,181 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  18 ) # 18. ref-mod.at:35: Separate sign positions
-    at_setup_line='ref-mod.at:35'
-    at_desc='Separate sign positions'
-    $at_quiet $ECHO_N " 18: Separate sign positions                      $ECHO_C"
+  18 ) # 18. subscripts.at:287: Subscript out of bounds in MOVE (1)
+    at_setup_line='subscripts.at:287'
+    at_desc='Subscript out of bounds in MOVE (1)'
+    $at_quiet $ECHO_N " 18: Subscript out of bounds in MOVE (1)          $ECHO_C"
     at_xfail=no
     (
-      echo "18. ref-mod.at:35: testing ..."
+      echo "18. subscripts.at:287: testing ..."
+      $at_traceon
+
+
+cat >prog.cob <<'_ATEOF'
+
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X.
+       PROCEDURE        DIVISION.
+           MOVE X(I) TO Z.
+           STOP RUN.
+_ATEOF
+
+
+$at_traceoff
+echo "subscripts.at:303: \${COMPILE} -o prog prog.cob"
+echo subscripts.at:303 >$at_check_line_file
+( $at_traceon; ${COMPILE} -o prog prog.cob ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+$at_diff $at_devnull $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   0) ;;
+   *) echo "subscripts.at:303: exit code was $at_status, expected 0"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+$at_traceoff
+echo "subscripts.at:304: ./prog"
+echo subscripts.at:304 >$at_check_line_file
+( $at_traceon; ./prog ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+echo >>$at_stderr; echo "prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
+" | $at_diff - $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   1) ;;
+   *) echo "subscripts.at:304: exit code was $at_status, expected 1"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+
+      $at_traceoff
+      $at_times_p && times >$at_times_file
+    ) 5>&1 2>&1 | eval $at_tee_pipe
+    at_status=`cat $at_status_file`
+    ;;
+
+  19 ) # 19. subscripts.at:311: Subscript out of bounds in MOVE (2)
+    at_setup_line='subscripts.at:311'
+    at_desc='Subscript out of bounds in MOVE (2)'
+    $at_quiet $ECHO_N " 19: Subscript out of bounds in MOVE (2)          $ECHO_C"
+    at_xfail=no
+    (
+      echo "19. subscripts.at:311: testing ..."
+      $at_traceon
+
+
+cat >prog.cob <<'_ATEOF'
+
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X.
+       PROCEDURE        DIVISION.
+           MOVE Z TO X(I).
+           STOP RUN.
+_ATEOF
+
+
+$at_traceoff
+echo "subscripts.at:327: \${COMPILE} -o prog prog.cob"
+echo subscripts.at:327 >$at_check_line_file
+( $at_traceon; ${COMPILE} -o prog prog.cob ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+$at_diff $at_devnull $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   0) ;;
+   *) echo "subscripts.at:327: exit code was $at_status, expected 0"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+$at_traceoff
+echo "subscripts.at:328: ./prog"
+echo subscripts.at:328 >$at_check_line_file
+( $at_traceon; ./prog ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+echo >>$at_stderr; echo "prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
+" | $at_diff - $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   1) ;;
+   *) echo "subscripts.at:328: exit code was $at_status, expected 1"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+
+      $at_traceoff
+      $at_times_p && times >$at_times_file
+    ) 5>&1 2>&1 | eval $at_tee_pipe
+    at_status=`cat $at_status_file`
+    ;;
+
+  20 ) # 20. ref-mod.at:35: Separate sign positions
+    at_setup_line='ref-mod.at:35'
+    at_desc='Separate sign positions'
+    $at_quiet $ECHO_N " 20: Separate sign positions                      $ECHO_C"
+    at_xfail=no
+    (
+      echo "20. ref-mod.at:35: testing ..."
       $at_traceon
 
 
@@ -2552,13 +2724,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  19 ) # 19. ref-mod.at:60: Static reference modification
+  21 ) # 21. ref-mod.at:60: Static reference modification
     at_setup_line='ref-mod.at:60'
     at_desc='Static reference modification'
-    $at_quiet $ECHO_N " 19: Static reference modification                $ECHO_C"
+    $at_quiet $ECHO_N " 21: Static reference modification                $ECHO_C"
     at_xfail=no
     (
-      echo "19. ref-mod.at:60: testing ..."
+      echo "21. ref-mod.at:60: testing ..."
       $at_traceon
 
 
@@ -2643,13 +2815,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  20 ) # 20. ref-mod.at:90: Dynamic reference modification
+  22 ) # 22. ref-mod.at:90: Dynamic reference modification
     at_setup_line='ref-mod.at:90'
     at_desc='Dynamic reference modification'
-    $at_quiet $ECHO_N " 20: Dynamic reference modification               $ECHO_C"
+    $at_quiet $ECHO_N " 22: Dynamic reference modification               $ECHO_C"
     at_xfail=no
     (
-      echo "20. ref-mod.at:90: testing ..."
+      echo "22. ref-mod.at:90: testing ..."
       $at_traceon
 
 
@@ -2735,13 +2907,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  21 ) # 21. ref-mod.at:121: Static out of bounds
+  23 ) # 23. ref-mod.at:121: Static out of bounds
     at_setup_line='ref-mod.at:121'
     at_desc='Static out of bounds'
-    $at_quiet $ECHO_N " 21: Static out of bounds                         $ECHO_C"
+    $at_quiet $ECHO_N " 23: Static out of bounds                         $ECHO_C"
     at_xfail=no
     (
-      echo "21. ref-mod.at:121: testing ..."
+      echo "23. ref-mod.at:121: testing ..."
       $at_traceon
 
 
@@ -2801,13 +2973,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  22 ) # 22. ref-mod.at:150: Offset underflow
+  24 ) # 24. ref-mod.at:150: Offset underflow
     at_setup_line='ref-mod.at:150'
     at_desc='Offset underflow'
-    $at_quiet $ECHO_N " 22: Offset underflow                             $ECHO_C"
+    $at_quiet $ECHO_N " 24: Offset underflow                             $ECHO_C"
     at_xfail=no
     (
-      echo "22. ref-mod.at:150: testing ..."
+      echo "24. ref-mod.at:150: testing ..."
       $at_traceon
 
 
@@ -2884,13 +3056,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  23 ) # 23. ref-mod.at:172: Offset overflow
+  25 ) # 25. ref-mod.at:172: Offset overflow
     at_setup_line='ref-mod.at:172'
     at_desc='Offset overflow'
-    $at_quiet $ECHO_N " 23: Offset overflow                              $ECHO_C"
+    $at_quiet $ECHO_N " 25: Offset overflow                              $ECHO_C"
     at_xfail=no
     (
-      echo "23. ref-mod.at:172: testing ..."
+      echo "25. ref-mod.at:172: testing ..."
       $at_traceon
 
 
@@ -2967,13 +3139,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  24 ) # 24. ref-mod.at:194: Length underflow
+  26 ) # 26. ref-mod.at:194: Length underflow
     at_setup_line='ref-mod.at:194'
     at_desc='Length underflow'
-    $at_quiet $ECHO_N " 24: Length underflow                             $ECHO_C"
+    $at_quiet $ECHO_N " 26: Length underflow                             $ECHO_C"
     at_xfail=no
     (
-      echo "24. ref-mod.at:194: testing ..."
+      echo "26. ref-mod.at:194: testing ..."
       $at_traceon
 
 
@@ -3050,13 +3222,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  25 ) # 25. ref-mod.at:216: Length overflow
+  27 ) # 27. ref-mod.at:216: Length overflow
     at_setup_line='ref-mod.at:216'
     at_desc='Length overflow'
-    $at_quiet $ECHO_N " 25: Length overflow                              $ECHO_C"
+    $at_quiet $ECHO_N " 27: Length overflow                              $ECHO_C"
     at_xfail=no
     (
-      echo "25. ref-mod.at:216: testing ..."
+      echo "27. ref-mod.at:216: testing ..."
       $at_traceon
 
 
@@ -3133,13 +3305,179 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  26 ) # 26. accept.at:23: ACCEPT
-    at_setup_line='accept.at:23'
-    at_desc='ACCEPT'
-    $at_quiet $ECHO_N " 26: ACCEPT                                       $ECHO_C"
+  28 ) # 28. ref-mod.at:241: Offset out of bounds in MOVE (1)
+    at_setup_line='ref-mod.at:241'
+    at_desc='Offset out of bounds in MOVE (1)'
+    $at_quiet $ECHO_N " 28: Offset out of bounds in MOVE (1)             $ECHO_C"
     at_xfail=no
     (
-      echo "26. accept.at:23: testing ..."
+      echo "28. ref-mod.at:241: testing ..."
+      $at_traceon
+
+
+cat >prog.cob <<'_ATEOF'
+
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(4) VALUE "abcd".
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X(4).
+       PROCEDURE        DIVISION.
+           MOVE X(I:4) TO Z.
+           STOP RUN.
+_ATEOF
+
+
+$at_traceoff
+echo "ref-mod.at:256: \${COMPILE} -o prog prog.cob"
+echo ref-mod.at:256 >$at_check_line_file
+( $at_traceon; ${COMPILE} -o prog prog.cob ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+$at_diff $at_devnull $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   0) ;;
+   *) echo "ref-mod.at:256: exit code was $at_status, expected 0"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+$at_traceoff
+echo "ref-mod.at:257: ./prog"
+echo ref-mod.at:257 >$at_check_line_file
+( $at_traceon; ./prog ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+echo >>$at_stderr; echo "prog.cob:10: libcob: Offset of 'X' out of bounds: 0
+" | $at_diff - $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   1) ;;
+   *) echo "ref-mod.at:257: exit code was $at_status, expected 1"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+
+      $at_traceoff
+      $at_times_p && times >$at_times_file
+    ) 5>&1 2>&1 | eval $at_tee_pipe
+    at_status=`cat $at_status_file`
+    ;;
+
+  29 ) # 29. ref-mod.at:264: Offset out of bounds in MOVE (2)
+    at_setup_line='ref-mod.at:264'
+    at_desc='Offset out of bounds in MOVE (2)'
+    $at_quiet $ECHO_N " 29: Offset out of bounds in MOVE (2)             $ECHO_C"
+    at_xfail=no
+    (
+      echo "29. ref-mod.at:264: testing ..."
+      $at_traceon
+
+
+cat >prog.cob <<'_ATEOF'
+
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(4).
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X(4) VALUE "abcd".
+       PROCEDURE        DIVISION.
+           MOVE Z TO X(I:4).
+           STOP RUN.
+_ATEOF
+
+
+$at_traceoff
+echo "ref-mod.at:279: \${COMPILE} -o prog prog.cob"
+echo ref-mod.at:279 >$at_check_line_file
+( $at_traceon; ${COMPILE} -o prog prog.cob ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+$at_diff $at_devnull $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   0) ;;
+   *) echo "ref-mod.at:279: exit code was $at_status, expected 0"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+$at_traceoff
+echo "ref-mod.at:280: ./prog"
+echo ref-mod.at:280 >$at_check_line_file
+( $at_traceon; ./prog ) >$at_stdout 2>$at_stder1
+at_status=$?
+grep '^ *+' $at_stder1 >&2
+grep -v '^ *+' $at_stder1 >$at_stderr
+at_failed=false
+echo >>$at_stderr; echo "prog.cob:10: libcob: Offset of 'X' out of bounds: 0
+" | $at_diff - $at_stderr || at_failed=:
+$at_diff $at_devnull $at_stdout || at_failed=:
+case $at_status in
+   77) echo 77 > $at_status_file
+            exit 77;;
+   1) ;;
+   *) echo "ref-mod.at:280: exit code was $at_status, expected 1"
+      at_failed=:;;
+esac
+if $at_failed; then
+
+  echo 1 > $at_status_file
+  exit 1
+fi
+
+$at_traceon
+
+
+      $at_traceoff
+      $at_times_p && times >$at_times_file
+    ) 5>&1 2>&1 | eval $at_tee_pipe
+    at_status=`cat $at_status_file`
+    ;;
+
+  30 ) # 30. accept.at:23: ACCEPT
+    at_setup_line='accept.at:23'
+    at_desc='ACCEPT'
+    $at_quiet $ECHO_N " 30: ACCEPT                                       $ECHO_C"
+    at_xfail=no
+    (
+      echo "30. accept.at:23: testing ..."
       $at_traceon
 
 
@@ -3236,13 +3574,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  27 ) # 27. initialize.at:27: INITIALIZE group entry with OCCURS
+  31 ) # 31. initialize.at:27: INITIALIZE group entry with OCCURS
     at_setup_line='initialize.at:27'
     at_desc='INITIALIZE group entry with OCCURS'
-    $at_quiet $ECHO_N " 27: INITIALIZE group entry with OCCURS           $ECHO_C"
+    $at_quiet $ECHO_N " 31: INITIALIZE group entry with OCCURS           $ECHO_C"
     at_xfail=no
     (
-      echo "27. initialize.at:27: testing ..."
+      echo "31. initialize.at:27: testing ..."
       $at_traceon
 
 
@@ -3322,13 +3660,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  28 ) # 28. initialize.at:52: INITIALIZE OCCURS with numeric edited
+  32 ) # 32. initialize.at:52: INITIALIZE OCCURS with numeric edited
     at_setup_line='initialize.at:52'
     at_desc='INITIALIZE OCCURS with numeric edited'
-    $at_quiet $ECHO_N " 28: INITIALIZE OCCURS with numeric edited        $ECHO_C"
+    $at_quiet $ECHO_N " 32: INITIALIZE OCCURS with numeric edited        $ECHO_C"
     at_xfail=no
     (
-      echo "28. initialize.at:52: testing ..."
+      echo "32. initialize.at:52: testing ..."
       $at_traceon
 
 
@@ -3406,13 +3744,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  29 ) # 29. initialize.at:75: INITIALIZE complex group (1)
+  33 ) # 33. initialize.at:75: INITIALIZE complex group (1)
     at_setup_line='initialize.at:75'
     at_desc='INITIALIZE complex group (1)'
-    $at_quiet $ECHO_N " 29: INITIALIZE complex group (1)                 $ECHO_C"
+    $at_quiet $ECHO_N " 33: INITIALIZE complex group (1)                 $ECHO_C"
     at_xfail=no
     (
-      echo "29. initialize.at:75: testing ..."
+      echo "33. initialize.at:75: testing ..."
       $at_traceon
 
 
@@ -3492,13 +3830,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  30 ) # 30. initialize.at:99: INITIALIZE complex group (2)
+  34 ) # 34. initialize.at:99: INITIALIZE complex group (2)
     at_setup_line='initialize.at:99'
     at_desc='INITIALIZE complex group (2)'
-    $at_quiet $ECHO_N " 30: INITIALIZE complex group (2)                 $ECHO_C"
+    $at_quiet $ECHO_N " 34: INITIALIZE complex group (2)                 $ECHO_C"
     at_xfail=no
     (
-      echo "30. initialize.at:99: testing ..."
+      echo "34. initialize.at:99: testing ..."
       $at_traceon
 
 
@@ -3578,13 +3916,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  31 ) # 31. initialize.at:123: INITIALIZE with REDEFINES
+  35 ) # 35. initialize.at:123: INITIALIZE with REDEFINES
     at_setup_line='initialize.at:123'
     at_desc='INITIALIZE with REDEFINES'
-    $at_quiet $ECHO_N " 31: INITIALIZE with REDEFINES                    $ECHO_C"
+    $at_quiet $ECHO_N " 35: INITIALIZE with REDEFINES                    $ECHO_C"
     at_xfail=no
     (
-      echo "31. initialize.at:123: testing ..."
+      echo "35. initialize.at:123: testing ..."
       $at_traceon
 
 
@@ -3663,13 +4001,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  32 ) # 32. misc.at:21: Source file not found
+  36 ) # 36. misc.at:21: Source file not found
     at_setup_line='misc.at:21'
     at_desc='Source file not found'
-    $at_quiet $ECHO_N " 32: Source file not found                        $ECHO_C"
+    $at_quiet $ECHO_N " 36: Source file not found                        $ECHO_C"
     at_xfail=no
     (
-      echo "32. misc.at:21: testing ..."
+      echo "36. misc.at:21: testing ..."
       $at_traceon
 
 
@@ -3706,13 +4044,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  33 ) # 33. misc.at:30: Comma separator without space
+  37 ) # 37. misc.at:30: Comma separator without space
     at_setup_line='misc.at:30'
     at_desc='Comma separator without space'
-    $at_quiet $ECHO_N " 33: Comma separator without space                $ECHO_C"
+    $at_quiet $ECHO_N " 37: Comma separator without space                $ECHO_C"
     at_xfail=no
     (
-      echo "33. misc.at:30: testing ..."
+      echo "37. misc.at:30: testing ..."
       $at_traceon
 
 
@@ -3784,13 +4122,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  34 ) # 34. misc.at:47: LOCAL-STORAGE
+  38 ) # 38. misc.at:47: LOCAL-STORAGE
     at_setup_line='misc.at:47'
     at_desc='LOCAL-STORAGE'
-    $at_quiet $ECHO_N " 34: LOCAL-STORAGE                                $ECHO_C"
+    $at_quiet $ECHO_N " 38: LOCAL-STORAGE                                $ECHO_C"
     at_xfail=no
     (
-      echo "34. misc.at:47: testing ..."
+      echo "38. misc.at:47: testing ..."
       $at_traceon
 
 
@@ -3912,13 +4250,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  35 ) # 35. misc.at:89: EXTERNAL data item
+  39 ) # 39. misc.at:89: EXTERNAL data item
     at_setup_line='misc.at:89'
     at_desc='EXTERNAL data item'
-    $at_quiet $ECHO_N " 35: EXTERNAL data item                           $ECHO_C"
+    $at_quiet $ECHO_N " 39: EXTERNAL data item                           $ECHO_C"
     at_xfail=no
     (
-      echo "35. misc.at:89: testing ..."
+      echo "39. misc.at:89: testing ..."
       $at_traceon
 
 
@@ -4040,13 +4378,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  36 ) # 36. misc.at:131: EXTERNAL AS data item
+  40 ) # 40. misc.at:131: EXTERNAL AS data item
     at_setup_line='misc.at:131'
     at_desc='EXTERNAL AS data item'
-    $at_quiet $ECHO_N " 36: EXTERNAL AS data item                        $ECHO_C"
+    $at_quiet $ECHO_N " 40: EXTERNAL AS data item                        $ECHO_C"
     at_xfail=no
     (
-      echo "36. misc.at:131: testing ..."
+      echo "40. misc.at:131: testing ..."
       $at_traceon
 
 
@@ -4172,13 +4510,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  37 ) # 37. misc.at:177: cobcrun validation
+  41 ) # 41. misc.at:177: cobcrun validation
     at_setup_line='misc.at:177'
     at_desc='cobcrun validation'
-    $at_quiet $ECHO_N " 37: cobcrun validation                           $ECHO_C"
+    $at_quiet $ECHO_N " 41: cobcrun validation                           $ECHO_C"
     at_xfail=no
     (
-      echo "37. misc.at:177: testing ..."
+      echo "41. misc.at:177: testing ..."
       $at_traceon
 
 
@@ -4300,13 +4638,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  38 ) # 38. misc.at:221: MOVE to itself
+  42 ) # 42. misc.at:221: MOVE to itself
     at_setup_line='misc.at:221'
     at_desc='MOVE to itself'
-    $at_quiet $ECHO_N " 38: MOVE to itself                               $ECHO_C"
+    $at_quiet $ECHO_N " 42: MOVE to itself                               $ECHO_C"
     at_xfail=no
     (
-      echo "38. misc.at:221: testing ..."
+      echo "42. misc.at:221: testing ..."
       $at_traceon
 
 
@@ -4382,13 +4720,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  39 ) # 39. misc.at:241: MOVE with refmod
+  43 ) # 43. misc.at:241: MOVE with refmod
     at_setup_line='misc.at:241'
     at_desc='MOVE with refmod'
-    $at_quiet $ECHO_N " 39: MOVE with refmod                             $ECHO_C"
+    $at_quiet $ECHO_N " 43: MOVE with refmod                             $ECHO_C"
     at_xfail=no
     (
-      echo "39. misc.at:241: testing ..."
+      echo "43. misc.at:241: testing ..."
       $at_traceon
 
 
@@ -4464,13 +4802,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  40 ) # 40. misc.at:261: MOVE with refmod (variable)
+  44 ) # 44. misc.at:261: MOVE with refmod (variable)
     at_setup_line='misc.at:261'
     at_desc='MOVE with refmod (variable)'
-    $at_quiet $ECHO_N " 40: MOVE with refmod (variable)                  $ECHO_C"
+    $at_quiet $ECHO_N " 44: MOVE with refmod (variable)                  $ECHO_C"
     at_xfail=no
     (
-      echo "40. misc.at:261: testing ..."
+      echo "44. misc.at:261: testing ..."
       $at_traceon
 
 
@@ -4548,13 +4886,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  41 ) # 41. misc.at:283: MOVE with group refmod
+  45 ) # 45. misc.at:283: MOVE with group refmod
     at_setup_line='misc.at:283'
     at_desc='MOVE with group refmod'
-    $at_quiet $ECHO_N " 41: MOVE with group refmod                       $ECHO_C"
+    $at_quiet $ECHO_N " 45: MOVE with group refmod                       $ECHO_C"
     at_xfail=no
     (
-      echo "41. misc.at:283: testing ..."
+      echo "45. misc.at:283: testing ..."
       $at_traceon
 
 
@@ -4631,13 +4969,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  42 ) # 42. misc.at:304: MOVE indexes
+  46 ) # 46. misc.at:304: MOVE indexes
     at_setup_line='misc.at:304'
     at_desc='MOVE indexes'
-    $at_quiet $ECHO_N " 42: MOVE indexes                                 $ECHO_C"
+    $at_quiet $ECHO_N " 46: MOVE indexes                                 $ECHO_C"
     at_xfail=no
     (
-      echo "42. misc.at:304: testing ..."
+      echo "46. misc.at:304: testing ..."
       $at_traceon
 
 
@@ -4715,13 +5053,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  43 ) # 43. misc.at:326: MOVE X'00'
+  47 ) # 47. misc.at:326: MOVE X'00'
     at_setup_line='misc.at:326'
     at_desc='MOVE X'00''
-    $at_quiet $ECHO_N " 43: MOVE X'00'                                   $ECHO_C"
+    $at_quiet $ECHO_N " 47: MOVE X'00'                                   $ECHO_C"
     at_xfail=no
     (
-      echo "43. misc.at:326: testing ..."
+      echo "47. misc.at:326: testing ..."
       $at_traceon
 
 
@@ -4835,13 +5173,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  44 ) # 44. misc.at:361: Level 01 subscripts
+  48 ) # 48. misc.at:361: Level 01 subscripts
     at_setup_line='misc.at:361'
     at_desc='Level 01 subscripts'
-    $at_quiet $ECHO_N " 44: Level 01 subscripts                          $ECHO_C"
+    $at_quiet $ECHO_N " 48: Level 01 subscripts                          $ECHO_C"
     at_xfail=no
     (
-      echo "44. misc.at:361: testing ..."
+      echo "48. misc.at:361: testing ..."
       $at_traceon
 
 
@@ -4890,13 +5228,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  45 ) # 45. misc.at:382: Class check with reference modification
+  49 ) # 49. misc.at:382: Class check with reference modification
     at_setup_line='misc.at:382'
     at_desc='Class check with reference modification'
-    $at_quiet $ECHO_N " 45: Class check with reference modification      $ECHO_C"
+    $at_quiet $ECHO_N " 49: Class check with reference modification      $ECHO_C"
     at_xfail=no
     (
-      echo "45. misc.at:382: testing ..."
+      echo "49. misc.at:382: testing ..."
       $at_traceon
 
 
@@ -4973,13 +5311,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  46 ) # 46. misc.at:403: Index and parenthesized expression
+  50 ) # 50. misc.at:403: Index and parenthesized expression
     at_setup_line='misc.at:403'
     at_desc='Index and parenthesized expression'
-    $at_quiet $ECHO_N " 46: Index and parenthesized expression           $ECHO_C"
+    $at_quiet $ECHO_N " 50: Index and parenthesized expression           $ECHO_C"
     at_xfail=no
     (
-      echo "46. misc.at:403: testing ..."
+      echo "50. misc.at:403: testing ..."
       $at_traceon
 
 
@@ -5031,13 +5369,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  47 ) # 47. misc.at:423: String concatenation
+  51 ) # 51. misc.at:423: String concatenation
     at_setup_line='misc.at:423'
     at_desc='String concatenation'
-    $at_quiet $ECHO_N " 47: String concatenation                         $ECHO_C"
+    $at_quiet $ECHO_N " 51: String concatenation                         $ECHO_C"
     at_xfail=no
     (
-      echo "47. misc.at:423: testing ..."
+      echo "51. misc.at:423: testing ..."
       $at_traceon
 
 
@@ -5127,13 +5465,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  48 ) # 48. misc.at:457: Alphanumeric and binary numeric
+  52 ) # 52. misc.at:457: Alphanumeric and binary numeric
     at_setup_line='misc.at:457'
     at_desc='Alphanumeric and binary numeric'
-    $at_quiet $ECHO_N " 48: Alphanumeric and binary numeric              $ECHO_C"
+    $at_quiet $ECHO_N " 52: Alphanumeric and binary numeric              $ECHO_C"
     at_xfail=no
     (
-      echo "48. misc.at:457: testing ..."
+      echo "52. misc.at:457: testing ..."
       $at_traceon
 
 
@@ -5210,13 +5548,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  49 ) # 49. misc.at:481: Dynamic call with static linking
+  53 ) # 53. misc.at:481: Dynamic call with static linking
     at_setup_line='misc.at:481'
     at_desc='Dynamic call with static linking'
-    $at_quiet $ECHO_N " 49: Dynamic call with static linking             $ECHO_C"
+    $at_quiet $ECHO_N " 53: Dynamic call with static linking             $ECHO_C"
     at_xfail=no
     (
-      echo "49. misc.at:481: testing ..."
+      echo "53. misc.at:481: testing ..."
       $at_traceon
 
 
@@ -5347,13 +5685,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  50 ) # 50. misc.at:506: CALL m1. CALL m2. CALL m1.
+  54 ) # 54. misc.at:506: CALL m1. CALL m2. CALL m1.
     at_setup_line='misc.at:506'
     at_desc='CALL m1. CALL m2. CALL m1.'
-    $at_quiet $ECHO_N " 50: CALL m1. CALL m2. CALL m1.                   $ECHO_C"
+    $at_quiet $ECHO_N " 54: CALL m1. CALL m2. CALL m1.                   $ECHO_C"
     at_xfail=no
     (
-      echo "50. misc.at:506: testing ..."
+      echo "54. misc.at:506: testing ..."
       $at_traceon
 
 
@@ -5513,13 +5851,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  51 ) # 51. misc.at:559: CALL binary literal parameter/LENGTH OF
+  55 ) # 55. misc.at:559: CALL binary literal parameter/LENGTH OF
     at_setup_line='misc.at:559'
     at_desc='CALL binary literal parameter/LENGTH OF'
-    $at_quiet $ECHO_N " 51: CALL binary literal parameter/LENGTH OF      $ECHO_C"
+    $at_quiet $ECHO_N " 55: CALL binary literal parameter/LENGTH OF      $ECHO_C"
     at_xfail=no
     (
-      echo "51. misc.at:559: testing ..."
+      echo "55. misc.at:559: testing ..."
       $at_traceon
 
 
@@ -5701,13 +6039,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  52 ) # 52. misc.at:614: INSPECT REPLACING LEADING ZEROS BY SPACES
+  56 ) # 56. misc.at:614: INSPECT REPLACING LEADING ZEROS BY SPACES
     at_setup_line='misc.at:614'
     at_desc='INSPECT REPLACING LEADING ZEROS BY SPACES'
-    $at_quiet $ECHO_N " 52: INSPECT REPLACING LEADING ZEROS BY SPACES    $ECHO_C"
+    $at_quiet $ECHO_N " 56: INSPECT REPLACING LEADING ZEROS BY SPACES    $ECHO_C"
     at_xfail=no
     (
-      echo "52. misc.at:614: testing ..."
+      echo "56. misc.at:614: testing ..."
       $at_traceon
 
 
@@ -5783,13 +6121,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  53 ) # 53. misc.at:634: INSPECT: No repeat conversion check
+  57 ) # 57. misc.at:634: INSPECT: No repeat conversion check
     at_setup_line='misc.at:634'
     at_desc='INSPECT: No repeat conversion check'
-    $at_quiet $ECHO_N " 53: INSPECT: No repeat conversion check          $ECHO_C"
+    $at_quiet $ECHO_N " 57: INSPECT: No repeat conversion check          $ECHO_C"
     at_xfail=no
     (
-      echo "53. misc.at:634: testing ..."
+      echo "57. misc.at:634: testing ..."
       $at_traceon
 
 
@@ -5865,13 +6203,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  54 ) # 54. misc.at:655: INSPECT CONVERTING spaces
+  58 ) # 58. misc.at:655: INSPECT CONVERTING spaces
     at_setup_line='misc.at:655'
     at_desc='INSPECT CONVERTING spaces'
-    $at_quiet $ECHO_N " 54: INSPECT CONVERTING spaces                    $ECHO_C"
+    $at_quiet $ECHO_N " 58: INSPECT CONVERTING spaces                    $ECHO_C"
     at_xfail=no
     (
-      echo "54. misc.at:655: testing ..."
+      echo "58. misc.at:655: testing ..."
       $at_traceon
 
 
@@ -5947,13 +6285,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  55 ) # 55. misc.at:676: INSPECT CONVERTING different length
+  59 ) # 59. misc.at:676: INSPECT CONVERTING different length
     at_setup_line='misc.at:676'
     at_desc='INSPECT CONVERTING different length'
-    $at_quiet $ECHO_N " 55: INSPECT CONVERTING different length          $ECHO_C"
+    $at_quiet $ECHO_N " 59: INSPECT CONVERTING different length          $ECHO_C"
     at_xfail=no
     (
-      echo "55. misc.at:676: testing ..."
+      echo "59. misc.at:676: testing ..."
       $at_traceon
 
 
@@ -6005,13 +6343,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  56 ) # 56. misc.at:698: INSPECT: REPLACING figurative constant
+  60 ) # 60. misc.at:698: INSPECT: REPLACING figurative constant
     at_setup_line='misc.at:698'
     at_desc='INSPECT: REPLACING figurative constant'
-    $at_quiet $ECHO_N " 56: INSPECT: REPLACING figurative constant       $ECHO_C"
+    $at_quiet $ECHO_N " 60: INSPECT: REPLACING figurative constant       $ECHO_C"
     at_xfail=no
     (
-      echo "56. misc.at:698: testing ..."
+      echo "60. misc.at:698: testing ..."
       $at_traceon
 
 
@@ -6087,13 +6425,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  57 ) # 57. misc.at:719: INSPECT: TALLYING BEFORE
+  61 ) # 61. misc.at:719: INSPECT: TALLYING BEFORE
     at_setup_line='misc.at:719'
     at_desc='INSPECT: TALLYING BEFORE'
-    $at_quiet $ECHO_N " 57: INSPECT: TALLYING BEFORE                     $ECHO_C"
+    $at_quiet $ECHO_N " 61: INSPECT: TALLYING BEFORE                     $ECHO_C"
     at_xfail=no
     (
-      echo "57. misc.at:719: testing ..."
+      echo "61. misc.at:719: testing ..."
       $at_traceon
 
 
@@ -6178,13 +6516,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  58 ) # 58. misc.at:749: INSPECT: TALLYING AFTER
+  62 ) # 62. misc.at:749: INSPECT: TALLYING AFTER
     at_setup_line='misc.at:749'
     at_desc='INSPECT: TALLYING AFTER'
-    $at_quiet $ECHO_N " 58: INSPECT: TALLYING AFTER                      $ECHO_C"
+    $at_quiet $ECHO_N " 62: INSPECT: TALLYING AFTER                      $ECHO_C"
     at_xfail=no
     (
-      echo "58. misc.at:749: testing ..."
+      echo "62. misc.at:749: testing ..."
       $at_traceon
 
 
@@ -6269,13 +6607,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  59 ) # 59. misc.at:778: INSPECT REPLACING TRAILING ZEROS BY SPACES
+  63 ) # 63. misc.at:778: INSPECT REPLACING TRAILING ZEROS BY SPACES
     at_setup_line='misc.at:778'
     at_desc='INSPECT REPLACING TRAILING ZEROS BY SPACES'
-    $at_quiet $ECHO_N " 59: INSPECT REPLACING TRAILING ZEROS BY SPACES   $ECHO_C"
+    $at_quiet $ECHO_N " 63: INSPECT REPLACING TRAILING ZEROS BY SPACES   $ECHO_C"
     at_xfail=no
     (
-      echo "59. misc.at:778: testing ..."
+      echo "63. misc.at:778: testing ..."
       $at_traceon
 
 
@@ -6351,13 +6689,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  60 ) # 60. misc.at:798: INSPECT REPLACING complex
+  64 ) # 64. misc.at:798: INSPECT REPLACING complex
     at_setup_line='misc.at:798'
     at_desc='INSPECT REPLACING complex'
-    $at_quiet $ECHO_N " 60: INSPECT REPLACING complex                    $ECHO_C"
+    $at_quiet $ECHO_N " 64: INSPECT REPLACING complex                    $ECHO_C"
     at_xfail=no
     (
-      echo "60. misc.at:798: testing ..."
+      echo "64. misc.at:798: testing ..."
       $at_traceon
 
 
@@ -6435,13 +6773,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  61 ) # 61. misc.at:820: SWITCHES
+  65 ) # 65. misc.at:820: SWITCHES
     at_setup_line='misc.at:820'
     at_desc='SWITCHES'
-    $at_quiet $ECHO_N " 61: SWITCHES                                     $ECHO_C"
+    $at_quiet $ECHO_N " 65: SWITCHES                                     $ECHO_C"
     at_xfail=no
     (
-      echo "61. misc.at:820: testing ..."
+      echo "65. misc.at:820: testing ..."
       $at_traceon
 
 
@@ -6552,13 +6890,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  62 ) # 62. misc.at:878: Nested PERFORM
+  66 ) # 66. misc.at:878: Nested PERFORM
     at_setup_line='misc.at:878'
     at_desc='Nested PERFORM'
-    $at_quiet $ECHO_N " 62: Nested PERFORM                               $ECHO_C"
+    $at_quiet $ECHO_N " 66: Nested PERFORM                               $ECHO_C"
     at_xfail=no
     (
-      echo "62. misc.at:878: testing ..."
+      echo "66. misc.at:878: testing ..."
       $at_traceon
 
 
@@ -6635,13 +6973,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  63 ) # 63. misc.at:903: EXIT PERFORM
+  67 ) # 67. misc.at:903: EXIT PERFORM
     at_setup_line='misc.at:903'
     at_desc='EXIT PERFORM'
-    $at_quiet $ECHO_N " 63: EXIT PERFORM                                 $ECHO_C"
+    $at_quiet $ECHO_N " 67: EXIT PERFORM                                 $ECHO_C"
     at_xfail=no
     (
-      echo "63. misc.at:903: testing ..."
+      echo "67. misc.at:903: testing ..."
       $at_traceon
 
 
@@ -6718,13 +7056,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  64 ) # 64. misc.at:927: EXIT PERFORM CYCLE
+  68 ) # 68. misc.at:927: EXIT PERFORM CYCLE
     at_setup_line='misc.at:927'
     at_desc='EXIT PERFORM CYCLE'
-    $at_quiet $ECHO_N " 64: EXIT PERFORM CYCLE                           $ECHO_C"
+    $at_quiet $ECHO_N " 68: EXIT PERFORM CYCLE                           $ECHO_C"
     at_xfail=no
     (
-      echo "64. misc.at:927: testing ..."
+      echo "68. misc.at:927: testing ..."
       $at_traceon
 
 
@@ -6801,13 +7139,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  65 ) # 65. misc.at:951: EXIT PARAGRAPH
+  69 ) # 69. misc.at:951: EXIT PARAGRAPH
     at_setup_line='misc.at:951'
     at_desc='EXIT PARAGRAPH'
-    $at_quiet $ECHO_N " 65: EXIT PARAGRAPH                               $ECHO_C"
+    $at_quiet $ECHO_N " 69: EXIT PARAGRAPH                               $ECHO_C"
     at_xfail=no
     (
-      echo "65. misc.at:951: testing ..."
+      echo "69. misc.at:951: testing ..."
       $at_traceon
 
 
@@ -6891,13 +7229,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  66 ) # 66. misc.at:982: EXIT SECTION
+  70 ) # 70. misc.at:982: EXIT SECTION
     at_setup_line='misc.at:982'
     at_desc='EXIT SECTION'
-    $at_quiet $ECHO_N " 66: EXIT SECTION                                 $ECHO_C"
+    $at_quiet $ECHO_N " 70: EXIT SECTION                                 $ECHO_C"
     at_xfail=no
     (
-      echo "66. misc.at:982: testing ..."
+      echo "70. misc.at:982: testing ..."
       $at_traceon
 
 
@@ -6986,13 +7324,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  67 ) # 67. misc.at:1016: 88 with FILLER
+  71 ) # 71. misc.at:1016: 88 with FILLER
     at_setup_line='misc.at:1016'
     at_desc='88 with FILLER'
-    $at_quiet $ECHO_N " 67: 88 with FILLER                               $ECHO_C"
+    $at_quiet $ECHO_N " 71: 88 with FILLER                               $ECHO_C"
     at_xfail=no
     (
-      echo "67. misc.at:1016: testing ..."
+      echo "71. misc.at:1016: testing ..."
       $at_traceon
 
 
@@ -7075,13 +7413,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  68 ) # 68. misc.at:1043: Non-overflow after overflow
+  72 ) # 72. misc.at:1043: Non-overflow after overflow
     at_setup_line='misc.at:1043'
     at_desc='Non-overflow after overflow'
-    $at_quiet $ECHO_N " 68: Non-overflow after overflow                  $ECHO_C"
+    $at_quiet $ECHO_N " 72: Non-overflow after overflow                  $ECHO_C"
     at_xfail=no
     (
-      echo "68. misc.at:1043: testing ..."
+      echo "72. misc.at:1043: testing ..."
       $at_traceon
 
 
@@ -7161,13 +7499,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  69 ) # 69. misc.at:1070: PERFORM ... CONTINUE
+  73 ) # 73. misc.at:1070: PERFORM ... CONTINUE
     at_setup_line='misc.at:1070'
     at_desc='PERFORM ... CONTINUE'
-    $at_quiet $ECHO_N " 69: PERFORM ... CONTINUE                         $ECHO_C"
+    $at_quiet $ECHO_N " 73: PERFORM ... CONTINUE                         $ECHO_C"
     at_xfail=no
     (
-      echo "69. misc.at:1070: testing ..."
+      echo "73. misc.at:1070: testing ..."
       $at_traceon
 
 
@@ -7214,13 +7552,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  70 ) # 70. misc.at:1086: STRING with subscript reference
+  74 ) # 74. misc.at:1086: STRING with subscript reference
     at_setup_line='misc.at:1086'
     at_desc='STRING with subscript reference'
-    $at_quiet $ECHO_N " 70: STRING with subscript reference              $ECHO_C"
+    $at_quiet $ECHO_N " 74: STRING with subscript reference              $ECHO_C"
     at_xfail=no
     (
-      echo "70. misc.at:1086: testing ..."
+      echo "74. misc.at:1086: testing ..."
       $at_traceon
 
 
@@ -7298,13 +7636,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  71 ) # 71. misc.at:1109: UNSTRING DELIMITED ALL LOW-VALUE
+  75 ) # 75. misc.at:1109: UNSTRING DELIMITED ALL LOW-VALUE
     at_setup_line='misc.at:1109'
     at_desc='UNSTRING DELIMITED ALL LOW-VALUE'
-    $at_quiet $ECHO_N " 71: UNSTRING DELIMITED ALL LOW-VALUE             $ECHO_C"
+    $at_quiet $ECHO_N " 75: UNSTRING DELIMITED ALL LOW-VALUE             $ECHO_C"
     at_xfail=no
     (
-      echo "71. misc.at:1109: testing ..."
+      echo "75. misc.at:1109: testing ..."
       $at_traceon
 
 
@@ -7391,13 +7729,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  72 ) # 72. misc.at:1142: READ INTO AT-END sequence
+  76 ) # 76. misc.at:1142: READ INTO AT-END sequence
     at_setup_line='misc.at:1142'
     at_desc='READ INTO AT-END sequence'
-    $at_quiet $ECHO_N " 72: READ INTO AT-END sequence                    $ECHO_C"
+    $at_quiet $ECHO_N " 76: READ INTO AT-END sequence                    $ECHO_C"
     at_xfail=no
     (
-      echo "72. misc.at:1142: testing ..."
+      echo "76. misc.at:1142: testing ..."
       $at_traceon
 
 
@@ -7486,13 +7824,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  73 ) # 73. misc.at:1176: First READ on empty SEQUENTIAL INDEXED file
+  77 ) # 77. misc.at:1176: First READ on empty SEQUENTIAL INDEXED file
     at_setup_line='misc.at:1176'
     at_desc='First READ on empty SEQUENTIAL INDEXED file'
-    $at_quiet $ECHO_N " 73: First READ on empty SEQUENTIAL INDEXED file  $ECHO_C"
+    $at_quiet $ECHO_N " 77: First READ on empty SEQUENTIAL INDEXED file  $ECHO_C"
     at_xfail=no
     (
-      echo "73. misc.at:1176: testing ..."
+      echo "77. misc.at:1176: testing ..."
       $at_traceon
 
 
@@ -7608,13 +7946,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  74 ) # 74. misc.at:1213: REWRITE a RELATIVE file with RANDOM access
+  78 ) # 78. misc.at:1213: REWRITE a RELATIVE file with RANDOM access
     at_setup_line='misc.at:1213'
     at_desc='REWRITE a RELATIVE file with RANDOM access'
-    $at_quiet $ECHO_N " 74: REWRITE a RELATIVE file with RANDOM access   $ECHO_C"
+    $at_quiet $ECHO_N " 78: REWRITE a RELATIVE file with RANDOM access   $ECHO_C"
     at_xfail=no
     (
-      echo "74. misc.at:1213: testing ..."
+      echo "78. misc.at:1213: testing ..."
       $at_traceon
 
 
@@ -7722,13 +8060,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  75 ) # 75. misc.at:1267: SORT: table sort
+  79 ) # 79. misc.at:1267: SORT: table sort
     at_setup_line='misc.at:1267'
     at_desc='SORT: table sort'
-    $at_quiet $ECHO_N " 75: SORT: table sort                             $ECHO_C"
+    $at_quiet $ECHO_N " 79: SORT: table sort                             $ECHO_C"
     at_xfail=no
     (
-      echo "75. misc.at:1267: testing ..."
+      echo "79. misc.at:1267: testing ..."
       $at_traceon
 
 
@@ -7820,13 +8158,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  76 ) # 76. misc.at:1304: SORT: EBCDIC table sort
+  80 ) # 80. misc.at:1304: SORT: EBCDIC table sort
     at_setup_line='misc.at:1304'
     at_desc='SORT: EBCDIC table sort'
-    $at_quiet $ECHO_N " 76: SORT: EBCDIC table sort                      $ECHO_C"
+    $at_quiet $ECHO_N " 80: SORT: EBCDIC table sort                      $ECHO_C"
     at_xfail=no
     (
-      echo "76. misc.at:1304: testing ..."
+      echo "80. misc.at:1304: testing ..."
       $at_traceon
 
 
@@ -7925,13 +8263,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  77 ) # 77. misc.at:1348: SORT nonexistent file
+  81 ) # 81. misc.at:1348: SORT nonexistent file
     at_setup_line='misc.at:1348'
     at_desc='SORT nonexistent file'
-    $at_quiet $ECHO_N " 77: SORT nonexistent file                        $ECHO_C"
+    $at_quiet $ECHO_N " 81: SORT nonexistent file                        $ECHO_C"
     at_xfail=no
     (
-      echo "77. misc.at:1348: testing ..."
+      echo "81. misc.at:1348: testing ..."
       $at_traceon
 
 
@@ -8044,13 +8382,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  78 ) # 78. misc.at:1382: PIC ZZZ-, ZZZ+
+  82 ) # 82. misc.at:1382: PIC ZZZ-, ZZZ+
     at_setup_line='misc.at:1382'
     at_desc='PIC ZZZ-, ZZZ+'
-    $at_quiet $ECHO_N " 78: PIC ZZZ-, ZZZ+                               $ECHO_C"
+    $at_quiet $ECHO_N " 82: PIC ZZZ-, ZZZ+                               $ECHO_C"
     at_xfail=no
     (
-      echo "78. misc.at:1382: testing ..."
+      echo "82. misc.at:1382: testing ..."
       $at_traceon
 
 
@@ -8142,13 +8480,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  79 ) # 79. misc.at:1420: Larger REDEFINES lengths
+  83 ) # 83. misc.at:1420: Larger REDEFINES lengths
     at_setup_line='misc.at:1420'
     at_desc='Larger REDEFINES lengths'
-    $at_quiet $ECHO_N " 79: Larger REDEFINES lengths                     $ECHO_C"
+    $at_quiet $ECHO_N " 83: Larger REDEFINES lengths                     $ECHO_C"
     at_xfail=no
     (
-      echo "79. misc.at:1420: testing ..."
+      echo "83. misc.at:1420: testing ..."
       $at_traceon
 
 
@@ -8242,13 +8580,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  80 ) # 80. misc.at:1460: PERFORM type OSVS
+  84 ) # 84. misc.at:1460: PERFORM type OSVS
     at_setup_line='misc.at:1460'
     at_desc='PERFORM type OSVS'
-    $at_quiet $ECHO_N " 80: PERFORM type OSVS                            $ECHO_C"
+    $at_quiet $ECHO_N " 84: PERFORM type OSVS                            $ECHO_C"
     at_xfail=no
     (
-      echo "80. misc.at:1460: testing ..."
+      echo "84. misc.at:1460: testing ..."
       $at_traceon
 
 
@@ -8345,13 +8683,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  81 ) # 81. misc.at:1501: Sticky LINKAGE
+  85 ) # 85. misc.at:1501: Sticky LINKAGE
     at_setup_line='misc.at:1501'
     at_desc='Sticky LINKAGE'
-    $at_quiet $ECHO_N " 81: Sticky LINKAGE                               $ECHO_C"
+    $at_quiet $ECHO_N " 85: Sticky LINKAGE                               $ECHO_C"
     at_xfail=no
     (
-      echo "81. misc.at:1501: testing ..."
+      echo "85. misc.at:1501: testing ..."
       $at_traceon
 
 
@@ -8484,13 +8822,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  82 ) # 82. misc.at:1551: COB_PRE_LOAD test
+  86 ) # 86. misc.at:1551: COB_PRE_LOAD test
     at_setup_line='misc.at:1551'
     at_desc='COB_PRE_LOAD test'
-    $at_quiet $ECHO_N " 82: COB_PRE_LOAD test                            $ECHO_C"
+    $at_quiet $ECHO_N " 86: COB_PRE_LOAD test                            $ECHO_C"
     at_xfail=no
     (
-      echo "82. misc.at:1551: testing ..."
+      echo "86. misc.at:1551: testing ..."
       $at_traceon
 
 
@@ -8596,13 +8934,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  83 ) # 83. misc.at:1575: COB_LOAD_CASE=UPPER test
+  87 ) # 87. misc.at:1575: COB_LOAD_CASE=UPPER test
     at_setup_line='misc.at:1575'
     at_desc='COB_LOAD_CASE=UPPER test'
-    $at_quiet $ECHO_N " 83: COB_LOAD_CASE=UPPER test                     $ECHO_C"
+    $at_quiet $ECHO_N " 87: COB_LOAD_CASE=UPPER test                     $ECHO_C"
     at_xfail=no
     (
-      echo "83. misc.at:1575: testing ..."
+      echo "87. misc.at:1575: testing ..."
       $at_traceon
 
 
@@ -8708,13 +9046,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  84 ) # 84. misc.at:1599: 88 level with FALSE IS clause
+  88 ) # 88. misc.at:1599: 88 level with FALSE IS clause
     at_setup_line='misc.at:1599'
     at_desc='88 level with FALSE IS clause'
-    $at_quiet $ECHO_N " 84: 88 level with FALSE IS clause                $ECHO_C"
+    $at_quiet $ECHO_N " 88: 88 level with FALSE IS clause                $ECHO_C"
     at_xfail=no
     (
-      echo "84. misc.at:1599: testing ..."
+      echo "88. misc.at:1599: testing ..."
       $at_traceon
 
 
@@ -8794,13 +9132,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  85 ) # 85. misc.at:1624: ALLOCATE/FREE with BASED item
+  89 ) # 89. misc.at:1624: ALLOCATE/FREE with BASED item
     at_setup_line='misc.at:1624'
     at_desc='ALLOCATE/FREE with BASED item'
-    $at_quiet $ECHO_N " 85: ALLOCATE/FREE with BASED item                $ECHO_C"
+    $at_quiet $ECHO_N " 89: ALLOCATE/FREE with BASED item                $ECHO_C"
     at_xfail=no
     (
-      echo "85. misc.at:1624: testing ..."
+      echo "89. misc.at:1624: testing ..."
       $at_traceon
 
 
@@ -8879,13 +9217,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  86 ) # 86. misc.at:1648: INITIZIALIZE with reference modification
+  90 ) # 90. misc.at:1648: INITIZIALIZE with reference modification
     at_setup_line='misc.at:1648'
     at_desc='INITIZIALIZE with reference modification'
-    $at_quiet $ECHO_N " 86: INITIZIALIZE with reference modification     $ECHO_C"
+    $at_quiet $ECHO_N " 90: INITIZIALIZE with reference modification     $ECHO_C"
     at_xfail=no
     (
-      echo "86. misc.at:1648: testing ..."
+      echo "90. misc.at:1648: testing ..."
       $at_traceon
 
 
@@ -8963,13 +9301,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  87 ) # 87. misc.at:1671: CALL with OMITTED parameter
+  91 ) # 91. misc.at:1671: CALL with OMITTED parameter
     at_setup_line='misc.at:1671'
     at_desc='CALL with OMITTED parameter'
-    $at_quiet $ECHO_N " 87: CALL with OMITTED parameter                  $ECHO_C"
+    $at_quiet $ECHO_N " 91: CALL with OMITTED parameter                  $ECHO_C"
     at_xfail=no
     (
-      echo "87. misc.at:1671: testing ..."
+      echo "91. misc.at:1671: testing ..."
       $at_traceon
 
 
@@ -9088,13 +9426,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  88 ) # 88. misc.at:1709: ANY LENGTH
+  92 ) # 92. misc.at:1709: ANY LENGTH
     at_setup_line='misc.at:1709'
     at_desc='ANY LENGTH'
-    $at_quiet $ECHO_N " 88: ANY LENGTH                                   $ECHO_C"
+    $at_quiet $ECHO_N " 92: ANY LENGTH                                   $ECHO_C"
     at_xfail=no
     (
-      echo "88. misc.at:1709: testing ..."
+      echo "92. misc.at:1709: testing ..."
       $at_traceon
 
 
@@ -9215,13 +9553,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  89 ) # 89. misc.at:1749: READ - KEY ignored with sequential READ
+  93 ) # 93. misc.at:1749: READ - KEY ignored with sequential READ
     at_setup_line='misc.at:1749'
     at_desc='READ - KEY ignored with sequential READ'
-    $at_quiet $ECHO_N " 89: READ - KEY ignored with sequential READ      $ECHO_C"
+    $at_quiet $ECHO_N " 93: READ - KEY ignored with sequential READ      $ECHO_C"
     at_xfail=no
     (
-      echo "89. misc.at:1749: testing ..."
+      echo "93. misc.at:1749: testing ..."
       $at_traceon
 
 
@@ -9285,13 +9623,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  90 ) # 90. misc.at:1782: SORT - missing fcd in variable-length WRITE
+  94 ) # 94. misc.at:1782: SORT - missing fcd in variable-length WRITE
     at_setup_line='misc.at:1782'
     at_desc='SORT - missing fcd in variable-length WRITE'
-    $at_quiet $ECHO_N " 90: SORT - missing fcd in variable-length WRITE  $ECHO_C"
+    $at_quiet $ECHO_N " 94: SORT - missing fcd in variable-length WRITE  $ECHO_C"
     at_xfail=no
     (
-      echo "90. misc.at:1782: testing ..."
+      echo "94. misc.at:1782: testing ..."
       $at_traceon
 
 
@@ -9434,13 +9772,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  91 ) # 91. misc.at:1869: READ - missing fcd in variable-length WRITE
+  95 ) # 95. misc.at:1869: READ - missing fcd in variable-length WRITE
     at_setup_line='misc.at:1869'
     at_desc='READ - missing fcd in variable-length WRITE'
-    $at_quiet $ECHO_N " 91: READ - missing fcd in variable-length WRITE  $ECHO_C"
+    $at_quiet $ECHO_N " 95: READ - missing fcd in variable-length WRITE  $ECHO_C"
     at_xfail=no
     (
-      echo "91. misc.at:1869: testing ..."
+      echo "95. misc.at:1869: testing ..."
       $at_traceon
 
 
@@ -9550,13 +9888,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  92 ) # 92. extensions.at:24: COMP-5
+  96 ) # 96. extensions.at:24: COMP-5
     at_setup_line='extensions.at:24'
     at_desc='COMP-5'
-    $at_quiet $ECHO_N " 92: COMP-5                                       $ECHO_C"
+    $at_quiet $ECHO_N " 96: COMP-5                                       $ECHO_C"
     at_xfail=no
     (
-      echo "92. extensions.at:24: testing ..."
+      echo "96. extensions.at:24: testing ..."
       $at_traceon
 
 
@@ -9681,13 +10019,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  93 ) # 93. extensions.at:71: Hexadecimal numeric literal
+  97 ) # 97. extensions.at:71: Hexadecimal numeric literal
     at_setup_line='extensions.at:71'
     at_desc='Hexadecimal numeric literal'
-    $at_quiet $ECHO_N " 93: Hexadecimal numeric literal                  $ECHO_C"
+    $at_quiet $ECHO_N " 97: Hexadecimal numeric literal                  $ECHO_C"
     at_xfail=no
     (
-      echo "93. extensions.at:71: testing ..."
+      echo "97. extensions.at:71: testing ..."
       $at_traceon
 
 
@@ -9767,13 +10105,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  94 ) # 94. extensions.at:99: Semi-parenthesized condition
+  98 ) # 98. extensions.at:99: Semi-parenthesized condition
     at_setup_line='extensions.at:99'
     at_desc='Semi-parenthesized condition'
-    $at_quiet $ECHO_N " 94: Semi-parenthesized condition                 $ECHO_C"
+    $at_quiet $ECHO_N " 98: Semi-parenthesized condition                 $ECHO_C"
     at_xfail=no
     (
-      echo "94. extensions.at:99: testing ..."
+      echo "98. extensions.at:99: testing ..."
       $at_traceon
 
 
@@ -9847,13 +10185,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  95 ) # 95. extensions.at:120: ADDRESS OF
+  99 ) # 99. extensions.at:120: ADDRESS OF
     at_setup_line='extensions.at:120'
     at_desc='ADDRESS OF'
-    $at_quiet $ECHO_N " 95: ADDRESS OF                                   $ECHO_C"
+    $at_quiet $ECHO_N " 99: ADDRESS OF                                   $ECHO_C"
     at_xfail=no
     (
-      echo "95. extensions.at:120: testing ..."
+      echo "99. extensions.at:120: testing ..."
       $at_traceon
 
 
@@ -9967,13 +10305,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  96 ) # 96. extensions.at:183: LENGTH OF
+  100 ) # 100. extensions.at:183: LENGTH OF
     at_setup_line='extensions.at:183'
     at_desc='LENGTH OF'
-    $at_quiet $ECHO_N " 96: LENGTH OF                                    $ECHO_C"
+    $at_quiet $ECHO_N "100: LENGTH OF                                    $ECHO_C"
     at_xfail=no
     (
-      echo "96. extensions.at:183: testing ..."
+      echo "100. extensions.at:183: testing ..."
       $at_traceon
 
 
@@ -10059,13 +10397,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  97 ) # 97. extensions.at:217: WHEN-COMPILED
+  101 ) # 101. extensions.at:217: WHEN-COMPILED
     at_setup_line='extensions.at:217'
     at_desc='WHEN-COMPILED'
-    $at_quiet $ECHO_N " 97: WHEN-COMPILED                                $ECHO_C"
+    $at_quiet $ECHO_N "101: WHEN-COMPILED                                $ECHO_C"
     at_xfail=no
     (
-      echo "97. extensions.at:217: testing ..."
+      echo "101. extensions.at:217: testing ..."
       $at_traceon
 
 
@@ -10141,13 +10479,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  98 ) # 98. extensions.at:240: Complex OCCURS DEPENDING ON
+  102 ) # 102. extensions.at:240: Complex OCCURS DEPENDING ON
     at_setup_line='extensions.at:240'
     at_desc='Complex OCCURS DEPENDING ON'
-    $at_quiet $ECHO_N " 98: Complex OCCURS DEPENDING ON                  $ECHO_C"
+    $at_quiet $ECHO_N "102: Complex OCCURS DEPENDING ON                  $ECHO_C"
     at_xfail=no
     (
-      echo "98. extensions.at:240: testing ..."
+      echo "102. extensions.at:240: testing ..."
       $at_traceon
 
 
@@ -10230,13 +10568,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  99 ) # 99. extensions.at:268: MOVE NON-INTEGER TO ALPHA-NUMERIC
+  103 ) # 103. extensions.at:268: MOVE NON-INTEGER TO ALPHA-NUMERIC
     at_setup_line='extensions.at:268'
     at_desc='MOVE NON-INTEGER TO ALPHA-NUMERIC'
-    $at_quiet $ECHO_N " 99: MOVE NON-INTEGER TO ALPHA-NUMERIC            $ECHO_C"
+    $at_quiet $ECHO_N "103: MOVE NON-INTEGER TO ALPHA-NUMERIC            $ECHO_C"
     at_xfail=no
     (
-      echo "99. extensions.at:268: testing ..."
+      echo "103. extensions.at:268: testing ..."
       $at_traceon
 
 #  see MF - COBOL  Error Messages  1029-E ...
@@ -10379,13 +10717,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  100 ) # 100. extensions.at:359: CALL USING file-name
+  104 ) # 104. extensions.at:359: CALL USING file-name
     at_setup_line='extensions.at:359'
     at_desc='CALL USING file-name'
-    $at_quiet $ECHO_N "100: CALL USING file-name                         $ECHO_C"
+    $at_quiet $ECHO_N "104: CALL USING file-name                         $ECHO_C"
     at_xfail=no
     (
-      echo "100. extensions.at:359: testing ..."
+      echo "104. extensions.at:359: testing ..."
       $at_traceon
 
 
@@ -10533,13 +10871,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  101 ) # 101. extensions.at:401: CALL unusual PROGRAM-ID.
+  105 ) # 105. extensions.at:401: CALL unusual PROGRAM-ID.
     at_setup_line='extensions.at:401'
     at_desc='CALL unusual PROGRAM-ID.'
-    $at_quiet $ECHO_N "101: CALL unusual PROGRAM-ID.                     $ECHO_C"
+    $at_quiet $ECHO_N "105: CALL unusual PROGRAM-ID.                     $ECHO_C"
     at_xfail=no
     (
-      echo "101. extensions.at:401: testing ..."
+      echo "105. extensions.at:401: testing ..."
       $at_traceon
 
 
@@ -10762,13 +11100,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  102 ) # 102. extensions.at:464: Case independent PROGRAM-ID
+  106 ) # 106. extensions.at:464: Case independent PROGRAM-ID
     at_setup_line='extensions.at:464'
     at_desc='Case independent PROGRAM-ID'
-    $at_quiet $ECHO_N "102: Case independent PROGRAM-ID                  $ECHO_C"
+    $at_quiet $ECHO_N "106: Case independent PROGRAM-ID                  $ECHO_C"
     at_xfail=no
     (
-      echo "102. extensions.at:464: testing ..."
+      echo "106. extensions.at:464: testing ..."
       $at_traceon
 
 
@@ -10847,13 +11185,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  103 ) # 103. extensions.at:487: PROGRAM-ID AS clause
+  107 ) # 107. extensions.at:487: PROGRAM-ID AS clause
     at_setup_line='extensions.at:487'
     at_desc='PROGRAM-ID AS clause'
-    $at_quiet $ECHO_N "103: PROGRAM-ID AS clause                         $ECHO_C"
+    $at_quiet $ECHO_N "107: PROGRAM-ID AS clause                         $ECHO_C"
     at_xfail=no
     (
-      echo "103. extensions.at:487: testing ..."
+      echo "107. extensions.at:487: testing ..."
       $at_traceon
 
 
@@ -10932,13 +11270,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  104 ) # 104. extensions.at:510: Quoted PROGRAM-ID
+  108 ) # 108. extensions.at:510: Quoted PROGRAM-ID
     at_setup_line='extensions.at:510'
     at_desc='Quoted PROGRAM-ID'
-    $at_quiet $ECHO_N "104: Quoted PROGRAM-ID                            $ECHO_C"
+    $at_quiet $ECHO_N "108: Quoted PROGRAM-ID                            $ECHO_C"
     at_xfail=no
     (
-      echo "104. extensions.at:510: testing ..."
+      echo "108. extensions.at:510: testing ..."
       $at_traceon
 
 
@@ -11017,13 +11355,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  105 ) # 105. extensions.at:535: ASSIGN MF
+  109 ) # 109. extensions.at:535: ASSIGN MF
     at_setup_line='extensions.at:535'
     at_desc='ASSIGN MF'
-    $at_quiet $ECHO_N "105: ASSIGN MF                                    $ECHO_C"
+    $at_quiet $ECHO_N "109: ASSIGN MF                                    $ECHO_C"
     at_xfail=no
     (
-      echo "105. extensions.at:535: testing ..."
+      echo "109. extensions.at:535: testing ..."
       $at_traceon
 
 
@@ -11112,13 +11450,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  106 ) # 106. extensions.at:567: ASSIGN IBM
+  110 ) # 110. extensions.at:567: ASSIGN IBM
     at_setup_line='extensions.at:567'
     at_desc='ASSIGN IBM'
-    $at_quiet $ECHO_N "106: ASSIGN IBM                                   $ECHO_C"
+    $at_quiet $ECHO_N "110: ASSIGN IBM                                   $ECHO_C"
     at_xfail=no
     (
-      echo "106. extensions.at:567: testing ..."
+      echo "110. extensions.at:567: testing ..."
       $at_traceon
 
 
@@ -11230,13 +11568,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  107 ) # 107. extensions.at:597: ASSIGN mapping
+  111 ) # 111. extensions.at:597: ASSIGN mapping
     at_setup_line='extensions.at:597'
     at_desc='ASSIGN mapping'
-    $at_quiet $ECHO_N "107: ASSIGN mapping                               $ECHO_C"
+    $at_quiet $ECHO_N "111: ASSIGN mapping                               $ECHO_C"
     at_xfail=no
     (
-      echo "107. extensions.at:597: testing ..."
+      echo "111. extensions.at:597: testing ..."
       $at_traceon
 
 
@@ -11498,13 +11836,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  108 ) # 108. extensions.at:633: ASSIGN expansion
+  112 ) # 112. extensions.at:633: ASSIGN expansion
     at_setup_line='extensions.at:633'
     at_desc='ASSIGN expansion'
-    $at_quiet $ECHO_N "108: ASSIGN expansion                             $ECHO_C"
+    $at_quiet $ECHO_N "112: ASSIGN expansion                             $ECHO_C"
     at_xfail=no
     (
-      echo "108. extensions.at:633: testing ..."
+      echo "112. extensions.at:633: testing ..."
       $at_traceon
 
 
@@ -11616,13 +11954,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  109 ) # 109. extensions.at:663: ASSIGN with COB_FILE_PATH
+  113 ) # 113. extensions.at:663: ASSIGN with COB_FILE_PATH
     at_setup_line='extensions.at:663'
     at_desc='ASSIGN with COB_FILE_PATH'
-    $at_quiet $ECHO_N "109: ASSIGN with COB_FILE_PATH                    $ECHO_C"
+    $at_quiet $ECHO_N "113: ASSIGN with COB_FILE_PATH                    $ECHO_C"
     at_xfail=no
     (
-      echo "109. extensions.at:663: testing ..."
+      echo "113. extensions.at:663: testing ..."
       $at_traceon
 
 
@@ -11734,13 +12072,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  110 ) # 110. extensions.at:696: NUMBER-OF-CALL-PARAMETERS
+  114 ) # 114. extensions.at:696: NUMBER-OF-CALL-PARAMETERS
     at_setup_line='extensions.at:696'
     at_desc='NUMBER-OF-CALL-PARAMETERS'
-    $at_quiet $ECHO_N "110: NUMBER-OF-CALL-PARAMETERS                    $ECHO_C"
+    $at_quiet $ECHO_N "114: NUMBER-OF-CALL-PARAMETERS                    $ECHO_C"
     at_xfail=no
     (
-      echo "110. extensions.at:696: testing ..."
+      echo "114. extensions.at:696: testing ..."
       $at_traceon
 
 
@@ -11874,13 +12212,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  111 ) # 111. extensions.at:752: PROCEDURE DIVISION USING BY ...
+  115 ) # 115. extensions.at:752: PROCEDURE DIVISION USING BY ...
     at_setup_line='extensions.at:752'
     at_desc='PROCEDURE DIVISION USING BY ...'
-    $at_quiet $ECHO_N "111: PROCEDURE DIVISION USING BY ...              $ECHO_C"
+    $at_quiet $ECHO_N "115: PROCEDURE DIVISION USING BY ...              $ECHO_C"
     at_xfail=no
     (
-      echo "111. extensions.at:752: testing ..."
+      echo "115. extensions.at:752: testing ..."
       $at_traceon
 
 
@@ -12010,13 +12348,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  112 ) # 112. extensions.at:801: PROCEDURE DIVISION CHAINING ...
+  116 ) # 116. extensions.at:801: PROCEDURE DIVISION CHAINING ...
     at_setup_line='extensions.at:801'
     at_desc='PROCEDURE DIVISION CHAINING ...'
-    $at_quiet $ECHO_N "112: PROCEDURE DIVISION CHAINING ...              $ECHO_C"
+    $at_quiet $ECHO_N "116: PROCEDURE DIVISION CHAINING ...              $ECHO_C"
     at_xfail=no
     (
-      echo "112. extensions.at:801: testing ..."
+      echo "116. extensions.at:801: testing ..."
       $at_traceon
 
 
@@ -12098,13 +12436,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  113 ) # 113. extensions.at:829: STOP RUN RETURNING
+  117 ) # 117. extensions.at:829: STOP RUN RETURNING
     at_setup_line='extensions.at:829'
     at_desc='STOP RUN RETURNING'
-    $at_quiet $ECHO_N "113: STOP RUN RETURNING                           $ECHO_C"
+    $at_quiet $ECHO_N "117: STOP RUN RETURNING                           $ECHO_C"
     at_xfail=no
     (
-      echo "113. extensions.at:829: testing ..."
+      echo "117. extensions.at:829: testing ..."
       $at_traceon
 
 
@@ -12174,13 +12512,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  114 ) # 114. extensions.at:846: ENTRY
+  118 ) # 118. extensions.at:846: ENTRY
     at_setup_line='extensions.at:846'
     at_desc='ENTRY'
-    $at_quiet $ECHO_N "114: ENTRY                                        $ECHO_C"
+    $at_quiet $ECHO_N "118: ENTRY                                        $ECHO_C"
     at_xfail=no
     (
-      echo "114. extensions.at:846: testing ..."
+      echo "118. extensions.at:846: testing ..."
       $at_traceon
 
 
@@ -12304,13 +12642,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  115 ) # 115. extensions.at:892: LINE SEQUENTIAL write
+  119 ) # 119. extensions.at:892: LINE SEQUENTIAL write
     at_setup_line='extensions.at:892'
     at_desc='LINE SEQUENTIAL write'
-    $at_quiet $ECHO_N "115: LINE SEQUENTIAL write                        $ECHO_C"
+    $at_quiet $ECHO_N "119: LINE SEQUENTIAL write                        $ECHO_C"
     at_xfail=no
     (
-      echo "115. extensions.at:892: testing ..."
+      echo "119. extensions.at:892: testing ..."
       $at_traceon
 
 
@@ -12430,13 +12768,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  116 ) # 116. extensions.at:933: LINE SEQUENTIAL read
+  120 ) # 120. extensions.at:933: LINE SEQUENTIAL read
     at_setup_line='extensions.at:933'
     at_desc='LINE SEQUENTIAL read'
-    $at_quiet $ECHO_N "116: LINE SEQUENTIAL read                         $ECHO_C"
+    $at_quiet $ECHO_N "120: LINE SEQUENTIAL read                         $ECHO_C"
     at_xfail=no
     (
-      echo "116. extensions.at:933: testing ..."
+      echo "120. extensions.at:933: testing ..."
       $at_traceon
 
 
@@ -12551,13 +12889,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  117 ) # 117. extensions.at:993: ASSIGN to KEYBOARD/DISPLAY
+  121 ) # 121. extensions.at:993: ASSIGN to KEYBOARD/DISPLAY
     at_setup_line='extensions.at:993'
     at_desc='ASSIGN to KEYBOARD/DISPLAY'
-    $at_quiet $ECHO_N "117: ASSIGN to KEYBOARD/DISPLAY                   $ECHO_C"
+    $at_quiet $ECHO_N "121: ASSIGN to KEYBOARD/DISPLAY                   $ECHO_C"
     at_xfail=no
     (
-      echo "117. extensions.at:993: testing ..."
+      echo "121. extensions.at:993: testing ..."
       $at_traceon
 
 
@@ -12669,13 +13007,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  118 ) # 118. extensions.at:1049: Environment/Argument variable
+  122 ) # 122. extensions.at:1049: Environment/Argument variable
     at_setup_line='extensions.at:1049'
     at_desc='Environment/Argument variable'
-    $at_quiet $ECHO_N "118: Environment/Argument variable                $ECHO_C"
+    $at_quiet $ECHO_N "122: Environment/Argument variable                $ECHO_C"
     at_xfail=no
     (
-      echo "118. extensions.at:1049: testing ..."
+      echo "122. extensions.at:1049: testing ..."
       $at_traceon
 
 
@@ -12775,13 +13113,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  119 ) # 119. extensions.at:1094: DECIMAL-POINT is COMMA (1)
+  123 ) # 123. extensions.at:1094: DECIMAL-POINT is COMMA (1)
     at_setup_line='extensions.at:1094'
     at_desc='DECIMAL-POINT is COMMA (1)'
-    $at_quiet $ECHO_N "119: DECIMAL-POINT is COMMA (1)                   $ECHO_C"
+    $at_quiet $ECHO_N "123: DECIMAL-POINT is COMMA (1)                   $ECHO_C"
     at_xfail=no
     (
-      echo "119. extensions.at:1094: testing ..."
+      echo "123. extensions.at:1094: testing ..."
       $at_traceon
 
 
@@ -12862,13 +13200,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  120 ) # 120. extensions.at:1120: DECIMAL-POINT is COMMA (2)
+  124 ) # 124. extensions.at:1120: DECIMAL-POINT is COMMA (2)
     at_setup_line='extensions.at:1120'
     at_desc='DECIMAL-POINT is COMMA (2)'
-    $at_quiet $ECHO_N "120: DECIMAL-POINT is COMMA (2)                   $ECHO_C"
+    $at_quiet $ECHO_N "124: DECIMAL-POINT is COMMA (2)                   $ECHO_C"
     at_xfail=no
     (
-      echo "120. extensions.at:1120: testing ..."
+      echo "124. extensions.at:1120: testing ..."
       $at_traceon
 
 
@@ -12949,13 +13287,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  121 ) # 121. extensions.at:1146: DECIMAL-POINT is COMMA (3)
+  125 ) # 125. extensions.at:1146: DECIMAL-POINT is COMMA (3)
     at_setup_line='extensions.at:1146'
     at_desc='DECIMAL-POINT is COMMA (3)'
-    $at_quiet $ECHO_N "121: DECIMAL-POINT is COMMA (3)                   $ECHO_C"
+    $at_quiet $ECHO_N "125: DECIMAL-POINT is COMMA (3)                   $ECHO_C"
     at_xfail=no
     (
-      echo "121. extensions.at:1146: testing ..."
+      echo "125. extensions.at:1146: testing ..."
       $at_traceon
 
 
@@ -13036,13 +13374,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  122 ) # 122. extensions.at:1172: DECIMAL-POINT is COMMA (4)
+  126 ) # 126. extensions.at:1172: DECIMAL-POINT is COMMA (4)
     at_setup_line='extensions.at:1172'
     at_desc='DECIMAL-POINT is COMMA (4)'
-    $at_quiet $ECHO_N "122: DECIMAL-POINT is COMMA (4)                   $ECHO_C"
+    $at_quiet $ECHO_N "126: DECIMAL-POINT is COMMA (4)                   $ECHO_C"
     at_xfail=no
     (
-      echo "122. extensions.at:1172: testing ..."
+      echo "126. extensions.at:1172: testing ..."
       $at_traceon
 
 
@@ -13123,13 +13461,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  123 ) # 123. extensions.at:1198: DECIMAL-POINT is COMMA (5)
+  127 ) # 127. extensions.at:1198: DECIMAL-POINT is COMMA (5)
     at_setup_line='extensions.at:1198'
     at_desc='DECIMAL-POINT is COMMA (5)'
-    $at_quiet $ECHO_N "123: DECIMAL-POINT is COMMA (5)                   $ECHO_C"
+    $at_quiet $ECHO_N "127: DECIMAL-POINT is COMMA (5)                   $ECHO_C"
     at_xfail=no
     (
-      echo "123. extensions.at:1198: testing ..."
+      echo "127. extensions.at:1198: testing ..."
       $at_traceon
 
 
@@ -13216,13 +13554,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  124 ) # 124. extensions.at:1230: 78 Level (1)
+  128 ) # 128. extensions.at:1230: 78 Level (1)
     at_setup_line='extensions.at:1230'
     at_desc='78 Level (1)'
-    $at_quiet $ECHO_N "124: 78 Level (1)                                 $ECHO_C"
+    $at_quiet $ECHO_N "128: 78 Level (1)                                 $ECHO_C"
     at_xfail=no
     (
-      echo "124. extensions.at:1230: testing ..."
+      echo "128. extensions.at:1230: testing ..."
       $at_traceon
 
 
@@ -13298,13 +13636,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  125 ) # 125. extensions.at:1251: 78 Level (2)
+  129 ) # 129. extensions.at:1251: 78 Level (2)
     at_setup_line='extensions.at:1251'
     at_desc='78 Level (2)'
-    $at_quiet $ECHO_N "125: 78 Level (2)                                 $ECHO_C"
+    $at_quiet $ECHO_N "129: 78 Level (2)                                 $ECHO_C"
     at_xfail=no
     (
-      echo "125. extensions.at:1251: testing ..."
+      echo "129. extensions.at:1251: testing ..."
       $at_traceon
 
 
@@ -13383,13 +13721,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  126 ) # 126. extensions.at:1275: 78 Level (3)
+  130 ) # 130. extensions.at:1275: 78 Level (3)
     at_setup_line='extensions.at:1275'
     at_desc='78 Level (3)'
-    $at_quiet $ECHO_N "126: 78 Level (3)                                 $ECHO_C"
+    $at_quiet $ECHO_N "130: 78 Level (3)                                 $ECHO_C"
     at_xfail=no
     (
-      echo "126. extensions.at:1275: testing ..."
+      echo "130. extensions.at:1275: testing ..."
       $at_traceon
 
 
@@ -13466,13 +13804,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  127 ) # 127. extensions.at:1297: Unreachable statement
+  131 ) # 131. extensions.at:1297: Unreachable statement
     at_setup_line='extensions.at:1297'
     at_desc='Unreachable statement'
-    $at_quiet $ECHO_N "127: Unreachable statement                        $ECHO_C"
+    $at_quiet $ECHO_N "131: Unreachable statement                        $ECHO_C"
     at_xfail=no
     (
-      echo "127. extensions.at:1297: testing ..."
+      echo "131. extensions.at:1297: testing ..."
       $at_traceon
 
 
@@ -13526,13 +13864,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  128 ) # 128. return-code.at:23: RETURN-CODE moving
+  132 ) # 132. return-code.at:23: RETURN-CODE moving
     at_setup_line='return-code.at:23'
     at_desc='RETURN-CODE moving'
-    $at_quiet $ECHO_N "128: RETURN-CODE moving                           $ECHO_C"
+    $at_quiet $ECHO_N "132: RETURN-CODE moving                           $ECHO_C"
     at_xfail=no
     (
-      echo "128. return-code.at:23: testing ..."
+      echo "132. return-code.at:23: testing ..."
       $at_traceon
 
 
@@ -13611,13 +13949,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  129 ) # 129. return-code.at:46: RETURN-CODE passing
+  133 ) # 133. return-code.at:46: RETURN-CODE passing
     at_setup_line='return-code.at:46'
     at_desc='RETURN-CODE passing'
-    $at_quiet $ECHO_N "129: RETURN-CODE passing                          $ECHO_C"
+    $at_quiet $ECHO_N "133: RETURN-CODE passing                          $ECHO_C"
     at_xfail=no
     (
-      echo "129. return-code.at:46: testing ..."
+      echo "133. return-code.at:46: testing ..."
       $at_traceon
 
 
@@ -13768,13 +14106,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  130 ) # 130. return-code.at:89: RETURN-CODE nested
+  134 ) # 134. return-code.at:89: RETURN-CODE nested
     at_setup_line='return-code.at:89'
     at_desc='RETURN-CODE nested'
-    $at_quiet $ECHO_N "130: RETURN-CODE nested                           $ECHO_C"
+    $at_quiet $ECHO_N "134: RETURN-CODE nested                           $ECHO_C"
     at_xfail=no
     (
-      echo "130. return-code.at:89: testing ..."
+      echo "134. return-code.at:89: testing ..."
       $at_traceon
 
 
@@ -13860,13 +14198,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  131 ) # 131. functions.at:22: FUNCTION ABS
+  135 ) # 135. functions.at:22: FUNCTION ABS
     at_setup_line='functions.at:22'
     at_desc='FUNCTION ABS'
-    $at_quiet $ECHO_N "131: FUNCTION ABS                                 $ECHO_C"
+    $at_quiet $ECHO_N "135: FUNCTION ABS                                 $ECHO_C"
     at_xfail=no
     (
-      echo "131. functions.at:22: testing ..."
+      echo "135. functions.at:22: testing ..."
       $at_traceon
 
 
@@ -13942,13 +14280,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  132 ) # 132. functions.at:43: FUNCTION ACOS
+  136 ) # 136. functions.at:43: FUNCTION ACOS
     at_setup_line='functions.at:43'
     at_desc='FUNCTION ACOS'
-    $at_quiet $ECHO_N "132: FUNCTION ACOS                                $ECHO_C"
+    $at_quiet $ECHO_N "136: FUNCTION ACOS                                $ECHO_C"
     at_xfail=no
     (
-      echo "132. functions.at:43: testing ..."
+      echo "136. functions.at:43: testing ..."
       $at_traceon
 
 
@@ -14032,13 +14370,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  133 ) # 133. functions.at:72: FUNCTION ANNUITY
+  137 ) # 137. functions.at:72: FUNCTION ANNUITY
     at_setup_line='functions.at:72'
     at_desc='FUNCTION ANNUITY'
-    $at_quiet $ECHO_N "133: FUNCTION ANNUITY                             $ECHO_C"
+    $at_quiet $ECHO_N "137: FUNCTION ANNUITY                             $ECHO_C"
     at_xfail=no
     (
-      echo "133. functions.at:72: testing ..."
+      echo "137. functions.at:72: testing ..."
       $at_traceon
 
 
@@ -14123,13 +14461,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  134 ) # 134. functions.at:102: FUNCTION ASIN
+  138 ) # 138. functions.at:102: FUNCTION ASIN
     at_setup_line='functions.at:102'
     at_desc='FUNCTION ASIN'
-    $at_quiet $ECHO_N "134: FUNCTION ASIN                                $ECHO_C"
+    $at_quiet $ECHO_N "138: FUNCTION ASIN                                $ECHO_C"
     at_xfail=no
     (
-      echo "134. functions.at:102: testing ..."
+      echo "138. functions.at:102: testing ..."
       $at_traceon
 
 
@@ -14213,13 +14551,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  135 ) # 135. functions.at:131: FUNCTION ATAN
+  139 ) # 139. functions.at:131: FUNCTION ATAN
     at_setup_line='functions.at:131'
     at_desc='FUNCTION ATAN'
-    $at_quiet $ECHO_N "135: FUNCTION ATAN                                $ECHO_C"
+    $at_quiet $ECHO_N "139: FUNCTION ATAN                                $ECHO_C"
     at_xfail=no
     (
-      echo "135. functions.at:131: testing ..."
+      echo "139. functions.at:131: testing ..."
       $at_traceon
 
 
@@ -14303,13 +14641,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  136 ) # 136. functions.at:160: FUNCTION CHAR
+  140 ) # 140. functions.at:160: FUNCTION CHAR
     at_setup_line='functions.at:160'
     at_desc='FUNCTION CHAR'
-    $at_quiet $ECHO_N "136: FUNCTION CHAR                                $ECHO_C"
+    $at_quiet $ECHO_N "140: FUNCTION CHAR                                $ECHO_C"
     at_xfail=no
     (
-      echo "136. functions.at:160: testing ..."
+      echo "140. functions.at:160: testing ..."
       $at_traceon
 
 
@@ -14385,13 +14723,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  137 ) # 137. functions.at:181: FUNCTION COMBINED-DATETIME
+  141 ) # 141. functions.at:181: FUNCTION COMBINED-DATETIME
     at_setup_line='functions.at:181'
     at_desc='FUNCTION COMBINED-DATETIME'
-    $at_quiet $ECHO_N "137: FUNCTION COMBINED-DATETIME                   $ECHO_C"
+    $at_quiet $ECHO_N "141: FUNCTION COMBINED-DATETIME                   $ECHO_C"
     at_xfail=no
     (
-      echo "137. functions.at:181: testing ..."
+      echo "141. functions.at:181: testing ..."
       $at_traceon
 
 
@@ -14466,13 +14804,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  138 ) # 138. functions.at:201: FUNCTION CONCATENATE
+  142 ) # 142. functions.at:201: FUNCTION CONCATENATE
     at_setup_line='functions.at:201'
     at_desc='FUNCTION CONCATENATE'
-    $at_quiet $ECHO_N "138: FUNCTION CONCATENATE                         $ECHO_C"
+    $at_quiet $ECHO_N "142: FUNCTION CONCATENATE                         $ECHO_C"
     at_xfail=no
     (
-      echo "138. functions.at:201: testing ..."
+      echo "142. functions.at:201: testing ..."
       $at_traceon
 
 
@@ -14549,13 +14887,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  139 ) # 139. functions.at:223: FUNCTION CONCATENATE with reference modding
+  143 ) # 143. functions.at:223: FUNCTION CONCATENATE with reference modding
     at_setup_line='functions.at:223'
     at_desc='FUNCTION CONCATENATE with reference modding'
-    $at_quiet $ECHO_N "139: FUNCTION CONCATENATE with reference modding  $ECHO_C"
+    $at_quiet $ECHO_N "143: FUNCTION CONCATENATE with reference modding  $ECHO_C"
     at_xfail=no
     (
-      echo "139. functions.at:223: testing ..."
+      echo "143. functions.at:223: testing ..."
       $at_traceon
 
 
@@ -14633,13 +14971,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  140 ) # 140. functions.at:246: FUNCTION COS
+  144 ) # 144. functions.at:246: FUNCTION COS
     at_setup_line='functions.at:246'
     at_desc='FUNCTION COS'
-    $at_quiet $ECHO_N "140: FUNCTION COS                                 $ECHO_C"
+    $at_quiet $ECHO_N "144: FUNCTION COS                                 $ECHO_C"
     at_xfail=no
     (
-      echo "140. functions.at:246: testing ..."
+      echo "144. functions.at:246: testing ..."
       $at_traceon
 
 
@@ -14723,13 +15061,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  141 ) # 141. functions.at:275: FUNCTION DATE-OF-INTEGER
+  145 ) # 145. functions.at:275: FUNCTION DATE-OF-INTEGER
     at_setup_line='functions.at:275'
     at_desc='FUNCTION DATE-OF-INTEGER'
-    $at_quiet $ECHO_N "141: FUNCTION DATE-OF-INTEGER                     $ECHO_C"
+    $at_quiet $ECHO_N "145: FUNCTION DATE-OF-INTEGER                     $ECHO_C"
     at_xfail=no
     (
-      echo "141. functions.at:275: testing ..."
+      echo "145. functions.at:275: testing ..."
       $at_traceon
 
 
@@ -14804,13 +15142,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  142 ) # 142. functions.at:295: FUNCTION DATE-TO-YYYYMMDD
+  146 ) # 146. functions.at:295: FUNCTION DATE-TO-YYYYMMDD
     at_setup_line='functions.at:295'
     at_desc='FUNCTION DATE-TO-YYYYMMDD'
-    $at_quiet $ECHO_N "142: FUNCTION DATE-TO-YYYYMMDD                    $ECHO_C"
+    $at_quiet $ECHO_N "146: FUNCTION DATE-TO-YYYYMMDD                    $ECHO_C"
     at_xfail=no
     (
-      echo "142. functions.at:295: testing ..."
+      echo "146. functions.at:295: testing ..."
       $at_traceon
 
 
@@ -14885,13 +15223,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  143 ) # 143. functions.at:315: FUNCTION DAY-OF-INTEGER
+  147 ) # 147. functions.at:315: FUNCTION DAY-OF-INTEGER
     at_setup_line='functions.at:315'
     at_desc='FUNCTION DAY-OF-INTEGER'
-    $at_quiet $ECHO_N "143: FUNCTION DAY-OF-INTEGER                      $ECHO_C"
+    $at_quiet $ECHO_N "147: FUNCTION DAY-OF-INTEGER                      $ECHO_C"
     at_xfail=no
     (
-      echo "143. functions.at:315: testing ..."
+      echo "147. functions.at:315: testing ..."
       $at_traceon
 
 
@@ -14966,13 +15304,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  144 ) # 144. functions.at:335: FUNCTION DAY-TO-YYYYDDD
+  148 ) # 148. functions.at:335: FUNCTION DAY-TO-YYYYDDD
     at_setup_line='functions.at:335'
     at_desc='FUNCTION DAY-TO-YYYYDDD'
-    $at_quiet $ECHO_N "144: FUNCTION DAY-TO-YYYYDDD                      $ECHO_C"
+    $at_quiet $ECHO_N "148: FUNCTION DAY-TO-YYYYDDD                      $ECHO_C"
     at_xfail=no
     (
-      echo "144. functions.at:335: testing ..."
+      echo "148. functions.at:335: testing ..."
       $at_traceon
 
 
@@ -15047,13 +15385,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  145 ) # 145. functions.at:355: FUNCTION E
+  149 ) # 149. functions.at:355: FUNCTION E
     at_setup_line='functions.at:355'
     at_desc='FUNCTION E'
-    $at_quiet $ECHO_N "145: FUNCTION E                                   $ECHO_C"
+    $at_quiet $ECHO_N "149: FUNCTION E                                   $ECHO_C"
     at_xfail=no
     (
-      echo "145. functions.at:355: testing ..."
+      echo "149. functions.at:355: testing ..."
       $at_traceon
 
 
@@ -15128,13 +15466,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  146 ) # 146. functions.at:375: FUNCTION EXCEPTION-FILE
+  150 ) # 150. functions.at:375: FUNCTION EXCEPTION-FILE
     at_setup_line='functions.at:375'
     at_desc='FUNCTION EXCEPTION-FILE'
-    $at_quiet $ECHO_N "146: FUNCTION EXCEPTION-FILE                      $ECHO_C"
+    $at_quiet $ECHO_N "150: FUNCTION EXCEPTION-FILE                      $ECHO_C"
     at_xfail=no
     (
-      echo "146. functions.at:375: testing ..."
+      echo "150. functions.at:375: testing ..."
       $at_traceon
 
 
@@ -15219,13 +15557,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  147 ) # 147. functions.at:405: FUNCTION EXCEPTION-LOCATION
+  151 ) # 151. functions.at:405: FUNCTION EXCEPTION-LOCATION
     at_setup_line='functions.at:405'
     at_desc='FUNCTION EXCEPTION-LOCATION'
-    $at_quiet $ECHO_N "147: FUNCTION EXCEPTION-LOCATION                  $ECHO_C"
+    $at_quiet $ECHO_N "151: FUNCTION EXCEPTION-LOCATION                  $ECHO_C"
     at_xfail=no
     (
-      echo "147. functions.at:405: testing ..."
+      echo "151. functions.at:405: testing ..."
       $at_traceon
 
 
@@ -15314,13 +15652,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  148 ) # 148. functions.at:439: FUNCTION EXCEPTION-STATEMENT
+  152 ) # 152. functions.at:439: FUNCTION EXCEPTION-STATEMENT
     at_setup_line='functions.at:439'
     at_desc='FUNCTION EXCEPTION-STATEMENT'
-    $at_quiet $ECHO_N "148: FUNCTION EXCEPTION-STATEMENT                 $ECHO_C"
+    $at_quiet $ECHO_N "152: FUNCTION EXCEPTION-STATEMENT                 $ECHO_C"
     at_xfail=no
     (
-      echo "148. functions.at:439: testing ..."
+      echo "152. functions.at:439: testing ..."
       $at_traceon
 
 
@@ -15405,13 +15743,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  149 ) # 149. functions.at:469: FUNCTION EXCEPTION-STATUS
+  153 ) # 153. functions.at:469: FUNCTION EXCEPTION-STATUS
     at_setup_line='functions.at:469'
     at_desc='FUNCTION EXCEPTION-STATUS'
-    $at_quiet $ECHO_N "149: FUNCTION EXCEPTION-STATUS                    $ECHO_C"
+    $at_quiet $ECHO_N "153: FUNCTION EXCEPTION-STATUS                    $ECHO_C"
     at_xfail=no
     (
-      echo "149. functions.at:469: testing ..."
+      echo "153. functions.at:469: testing ..."
       $at_traceon
 
 
@@ -15496,13 +15834,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  150 ) # 150. functions.at:499: FUNCTION EXP
+  154 ) # 154. functions.at:499: FUNCTION EXP
     at_setup_line='functions.at:499'
     at_desc='FUNCTION EXP'
-    $at_quiet $ECHO_N "150: FUNCTION EXP                                 $ECHO_C"
+    $at_quiet $ECHO_N "154: FUNCTION EXP                                 $ECHO_C"
     at_xfail=no
     (
-      echo "150. functions.at:499: testing ..."
+      echo "154. functions.at:499: testing ..."
       $at_traceon
 
 
@@ -15585,13 +15923,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  151 ) # 151. functions.at:527: FUNCTION FACTORIAL
+  155 ) # 155. functions.at:527: FUNCTION FACTORIAL
     at_setup_line='functions.at:527'
     at_desc='FUNCTION FACTORIAL'
-    $at_quiet $ECHO_N "151: FUNCTION FACTORIAL                           $ECHO_C"
+    $at_quiet $ECHO_N "155: FUNCTION FACTORIAL                           $ECHO_C"
     at_xfail=no
     (
-      echo "151. functions.at:527: testing ..."
+      echo "155. functions.at:527: testing ..."
       $at_traceon
 
 
@@ -15666,13 +16004,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  152 ) # 152. functions.at:547: FUNCTION FRACTION-PART
+  156 ) # 156. functions.at:547: FUNCTION FRACTION-PART
     at_setup_line='functions.at:547'
     at_desc='FUNCTION FRACTION-PART'
-    $at_quiet $ECHO_N "152: FUNCTION FRACTION-PART                       $ECHO_C"
+    $at_quiet $ECHO_N "156: FUNCTION FRACTION-PART                       $ECHO_C"
     at_xfail=no
     (
-      echo "152. functions.at:547: testing ..."
+      echo "156. functions.at:547: testing ..."
       $at_traceon
 
 
@@ -15750,13 +16088,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  153 ) # 153. functions.at:570: FUNCTION INTEGER
+  157 ) # 157. functions.at:570: FUNCTION INTEGER
     at_setup_line='functions.at:570'
     at_desc='FUNCTION INTEGER'
-    $at_quiet $ECHO_N "153: FUNCTION INTEGER                             $ECHO_C"
+    $at_quiet $ECHO_N "157: FUNCTION INTEGER                             $ECHO_C"
     at_xfail=no
     (
-      echo "153. functions.at:570: testing ..."
+      echo "157. functions.at:570: testing ..."
       $at_traceon
 
 
@@ -15832,13 +16170,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  154 ) # 154. functions.at:591: FUNCTION INTEGER-OF-DATE
+  158 ) # 158. functions.at:591: FUNCTION INTEGER-OF-DATE
     at_setup_line='functions.at:591'
     at_desc='FUNCTION INTEGER-OF-DATE'
-    $at_quiet $ECHO_N "154: FUNCTION INTEGER-OF-DATE                     $ECHO_C"
+    $at_quiet $ECHO_N "158: FUNCTION INTEGER-OF-DATE                     $ECHO_C"
     at_xfail=no
     (
-      echo "154. functions.at:591: testing ..."
+      echo "158. functions.at:591: testing ..."
       $at_traceon
 
 
@@ -15913,13 +16251,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  155 ) # 155. functions.at:611: FUNCTION INTEGER-OF-DAY
+  159 ) # 159. functions.at:611: FUNCTION INTEGER-OF-DAY
     at_setup_line='functions.at:611'
     at_desc='FUNCTION INTEGER-OF-DAY'
-    $at_quiet $ECHO_N "155: FUNCTION INTEGER-OF-DAY                      $ECHO_C"
+    $at_quiet $ECHO_N "159: FUNCTION INTEGER-OF-DAY                      $ECHO_C"
     at_xfail=no
     (
-      echo "155. functions.at:611: testing ..."
+      echo "159. functions.at:611: testing ..."
       $at_traceon
 
 
@@ -15994,13 +16332,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  156 ) # 156. functions.at:631: FUNCTION INTEGER-PART
+  160 ) # 160. functions.at:631: FUNCTION INTEGER-PART
     at_setup_line='functions.at:631'
     at_desc='FUNCTION INTEGER-PART'
-    $at_quiet $ECHO_N "156: FUNCTION INTEGER-PART                        $ECHO_C"
+    $at_quiet $ECHO_N "160: FUNCTION INTEGER-PART                        $ECHO_C"
     at_xfail=no
     (
-      echo "156. functions.at:631: testing ..."
+      echo "160. functions.at:631: testing ..."
       $at_traceon
 
 
@@ -16076,13 +16414,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  157 ) # 157. functions.at:652: FUNCTION LENGTH
+  161 ) # 161. functions.at:652: FUNCTION LENGTH
     at_setup_line='functions.at:652'
     at_desc='FUNCTION LENGTH'
-    $at_quiet $ECHO_N "157: FUNCTION LENGTH                              $ECHO_C"
+    $at_quiet $ECHO_N "161: FUNCTION LENGTH                              $ECHO_C"
     at_xfail=no
     (
-      echo "157. functions.at:652: testing ..."
+      echo "161. functions.at:652: testing ..."
       $at_traceon
 
 
@@ -16158,13 +16496,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  158 ) # 158. functions.at:673: FUNCTION LOCALE-DATE
+  162 ) # 162. functions.at:673: FUNCTION LOCALE-DATE
     at_setup_line='functions.at:673'
     at_desc='FUNCTION LOCALE-DATE'
-    $at_quiet $ECHO_N "158: FUNCTION LOCALE-DATE                         $ECHO_C"
+    $at_quiet $ECHO_N "162: FUNCTION LOCALE-DATE                         $ECHO_C"
     at_xfail=no
     (
-      echo "158. functions.at:673: testing ..."
+      echo "162. functions.at:673: testing ..."
       $at_traceon
 
 
@@ -16243,13 +16581,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  159 ) # 159. functions.at:697: FUNCTION LOCALE-TIME
+  163 ) # 163. functions.at:697: FUNCTION LOCALE-TIME
     at_setup_line='functions.at:697'
     at_desc='FUNCTION LOCALE-TIME'
-    $at_quiet $ECHO_N "159: FUNCTION LOCALE-TIME                         $ECHO_C"
+    $at_quiet $ECHO_N "163: FUNCTION LOCALE-TIME                         $ECHO_C"
     at_xfail=no
     (
-      echo "159. functions.at:697: testing ..."
+      echo "163. functions.at:697: testing ..."
       $at_traceon
 
 
@@ -16328,13 +16666,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  160 ) # 160. functions.at:721: FUNCTION LOCALE-TIME-FROM-SECONDS
+  164 ) # 164. functions.at:721: FUNCTION LOCALE-TIME-FROM-SECONDS
     at_setup_line='functions.at:721'
     at_desc='FUNCTION LOCALE-TIME-FROM-SECONDS'
-    $at_quiet $ECHO_N "160: FUNCTION LOCALE-TIME-FROM-SECONDS            $ECHO_C"
+    $at_quiet $ECHO_N "164: FUNCTION LOCALE-TIME-FROM-SECONDS            $ECHO_C"
     at_xfail=no
     (
-      echo "160. functions.at:721: testing ..."
+      echo "164. functions.at:721: testing ..."
       $at_traceon
 
 
@@ -16413,13 +16751,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  161 ) # 161. functions.at:745: FUNCTION LOG
+  165 ) # 165. functions.at:745: FUNCTION LOG
     at_setup_line='functions.at:745'
     at_desc='FUNCTION LOG'
-    $at_quiet $ECHO_N "161: FUNCTION LOG                                 $ECHO_C"
+    $at_quiet $ECHO_N "165: FUNCTION LOG                                 $ECHO_C"
     at_xfail=no
     (
-      echo "161. functions.at:745: testing ..."
+      echo "165. functions.at:745: testing ..."
       $at_traceon
 
 
@@ -16503,13 +16841,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  162 ) # 162. functions.at:774: FUNCTION LOG10
+  166 ) # 166. functions.at:774: FUNCTION LOG10
     at_setup_line='functions.at:774'
     at_desc='FUNCTION LOG10'
-    $at_quiet $ECHO_N "162: FUNCTION LOG10                               $ECHO_C"
+    $at_quiet $ECHO_N "166: FUNCTION LOG10                               $ECHO_C"
     at_xfail=no
     (
-      echo "162. functions.at:774: testing ..."
+      echo "166. functions.at:774: testing ..."
       $at_traceon
 
 
@@ -16593,13 +16931,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  163 ) # 163. functions.at:803: FUNCTION LOWER-CASE
+  167 ) # 167. functions.at:803: FUNCTION LOWER-CASE
     at_setup_line='functions.at:803'
     at_desc='FUNCTION LOWER-CASE'
-    $at_quiet $ECHO_N "163: FUNCTION LOWER-CASE                          $ECHO_C"
+    $at_quiet $ECHO_N "167: FUNCTION LOWER-CASE                          $ECHO_C"
     at_xfail=no
     (
-      echo "163. functions.at:803: testing ..."
+      echo "167. functions.at:803: testing ..."
       $at_traceon
 
 
@@ -16675,13 +17013,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  164 ) # 164. functions.at:824: FUNCTION LOWER-CASE with reference modding
+  168 ) # 168. functions.at:824: FUNCTION LOWER-CASE with reference modding
     at_setup_line='functions.at:824'
     at_desc='FUNCTION LOWER-CASE with reference modding'
-    $at_quiet $ECHO_N "164: FUNCTION LOWER-CASE with reference modding   $ECHO_C"
+    $at_quiet $ECHO_N "168: FUNCTION LOWER-CASE with reference modding   $ECHO_C"
     at_xfail=no
     (
-      echo "164. functions.at:824: testing ..."
+      echo "168. functions.at:824: testing ..."
       $at_traceon
 
 
@@ -16757,13 +17095,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  165 ) # 165. functions.at:845: FUNCTION MAX
+  169 ) # 169. functions.at:845: FUNCTION MAX
     at_setup_line='functions.at:845'
     at_desc='FUNCTION MAX'
-    $at_quiet $ECHO_N "165: FUNCTION MAX                                 $ECHO_C"
+    $at_quiet $ECHO_N "169: FUNCTION MAX                                 $ECHO_C"
     at_xfail=no
     (
-      echo "165. functions.at:845: testing ..."
+      echo "169. functions.at:845: testing ..."
       $at_traceon
 
 
@@ -16838,13 +17176,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  166 ) # 166. functions.at:865: FUNCTION MEAN
+  170 ) # 170. functions.at:865: FUNCTION MEAN
     at_setup_line='functions.at:865'
     at_desc='FUNCTION MEAN'
-    $at_quiet $ECHO_N "166: FUNCTION MEAN                                $ECHO_C"
+    $at_quiet $ECHO_N "170: FUNCTION MEAN                                $ECHO_C"
     at_xfail=no
     (
-      echo "166. functions.at:865: testing ..."
+      echo "170. functions.at:865: testing ..."
       $at_traceon
 
 
@@ -16919,13 +17257,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  167 ) # 167. functions.at:885: FUNCTION MEDIAN
+  171 ) # 171. functions.at:885: FUNCTION MEDIAN
     at_setup_line='functions.at:885'
     at_desc='FUNCTION MEDIAN'
-    $at_quiet $ECHO_N "167: FUNCTION MEDIAN                              $ECHO_C"
+    $at_quiet $ECHO_N "171: FUNCTION MEDIAN                              $ECHO_C"
     at_xfail=no
     (
-      echo "167. functions.at:885: testing ..."
+      echo "171. functions.at:885: testing ..."
       $at_traceon
 
 
@@ -17000,13 +17338,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  168 ) # 168. functions.at:905: FUNCTION MIDRANGE
+  172 ) # 172. functions.at:905: FUNCTION MIDRANGE
     at_setup_line='functions.at:905'
     at_desc='FUNCTION MIDRANGE'
-    $at_quiet $ECHO_N "168: FUNCTION MIDRANGE                            $ECHO_C"
+    $at_quiet $ECHO_N "172: FUNCTION MIDRANGE                            $ECHO_C"
     at_xfail=no
     (
-      echo "168. functions.at:905: testing ..."
+      echo "172. functions.at:905: testing ..."
       $at_traceon
 
 
@@ -17081,13 +17419,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  169 ) # 169. functions.at:925: FUNCTION MIN
+  173 ) # 173. functions.at:925: FUNCTION MIN
     at_setup_line='functions.at:925'
     at_desc='FUNCTION MIN'
-    $at_quiet $ECHO_N "169: FUNCTION MIN                                 $ECHO_C"
+    $at_quiet $ECHO_N "173: FUNCTION MIN                                 $ECHO_C"
     at_xfail=no
     (
-      echo "169. functions.at:925: testing ..."
+      echo "173. functions.at:925: testing ..."
       $at_traceon
 
 
@@ -17162,13 +17500,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  170 ) # 170. functions.at:945: FUNCTION MOD
+  174 ) # 174. functions.at:945: FUNCTION MOD
     at_setup_line='functions.at:945'
     at_desc='FUNCTION MOD'
-    $at_quiet $ECHO_N "170: FUNCTION MOD                                 $ECHO_C"
+    $at_quiet $ECHO_N "174: FUNCTION MOD                                 $ECHO_C"
     at_xfail=no
     (
-      echo "170. functions.at:945: testing ..."
+      echo "174. functions.at:945: testing ..."
       $at_traceon
 
 
@@ -17243,13 +17581,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  171 ) # 171. functions.at:965: FUNCTION NUMVAL
+  175 ) # 175. functions.at:965: FUNCTION NUMVAL
     at_setup_line='functions.at:965'
     at_desc='FUNCTION NUMVAL'
-    $at_quiet $ECHO_N "171: FUNCTION NUMVAL                              $ECHO_C"
+    $at_quiet $ECHO_N "175: FUNCTION NUMVAL                              $ECHO_C"
     at_xfail=no
     (
-      echo "171. functions.at:965: testing ..."
+      echo "175. functions.at:965: testing ..."
       $at_traceon
 
 
@@ -17325,13 +17663,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  172 ) # 172. functions.at:986: FUNCTION NUMVAL-C
+  176 ) # 176. functions.at:986: FUNCTION NUMVAL-C
     at_setup_line='functions.at:986'
     at_desc='FUNCTION NUMVAL-C'
-    $at_quiet $ECHO_N "172: FUNCTION NUMVAL-C                            $ECHO_C"
+    $at_quiet $ECHO_N "176: FUNCTION NUMVAL-C                            $ECHO_C"
     at_xfail=no
     (
-      echo "172. functions.at:986: testing ..."
+      echo "176. functions.at:986: testing ..."
       $at_traceon
 
 
@@ -17407,13 +17745,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  173 ) # 173. functions.at:1007: FUNCTION ORD
+  177 ) # 177. functions.at:1007: FUNCTION ORD
     at_setup_line='functions.at:1007'
     at_desc='FUNCTION ORD'
-    $at_quiet $ECHO_N "173: FUNCTION ORD                                 $ECHO_C"
+    $at_quiet $ECHO_N "177: FUNCTION ORD                                 $ECHO_C"
     at_xfail=no
     (
-      echo "173. functions.at:1007: testing ..."
+      echo "177. functions.at:1007: testing ..."
       $at_traceon
 
 
@@ -17488,13 +17826,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  174 ) # 174. functions.at:1027: FUNCTION ORD-MAX
+  178 ) # 178. functions.at:1027: FUNCTION ORD-MAX
     at_setup_line='functions.at:1027'
     at_desc='FUNCTION ORD-MAX'
-    $at_quiet $ECHO_N "174: FUNCTION ORD-MAX                             $ECHO_C"
+    $at_quiet $ECHO_N "178: FUNCTION ORD-MAX                             $ECHO_C"
     at_xfail=no
     (
-      echo "174. functions.at:1027: testing ..."
+      echo "178. functions.at:1027: testing ..."
       $at_traceon
 
 
@@ -17569,13 +17907,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  175 ) # 175. functions.at:1047: FUNCTION ORD-MIN
+  179 ) # 179. functions.at:1047: FUNCTION ORD-MIN
     at_setup_line='functions.at:1047'
     at_desc='FUNCTION ORD-MIN'
-    $at_quiet $ECHO_N "175: FUNCTION ORD-MIN                             $ECHO_C"
+    $at_quiet $ECHO_N "179: FUNCTION ORD-MIN                             $ECHO_C"
     at_xfail=no
     (
-      echo "175. functions.at:1047: testing ..."
+      echo "179. functions.at:1047: testing ..."
       $at_traceon
 
 
@@ -17650,13 +17988,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  176 ) # 176. functions.at:1067: FUNCTION PI
+  180 ) # 180. functions.at:1067: FUNCTION PI
     at_setup_line='functions.at:1067'
     at_desc='FUNCTION PI'
-    $at_quiet $ECHO_N "176: FUNCTION PI                                  $ECHO_C"
+    $at_quiet $ECHO_N "180: FUNCTION PI                                  $ECHO_C"
     at_xfail=no
     (
-      echo "176. functions.at:1067: testing ..."
+      echo "180. functions.at:1067: testing ..."
       $at_traceon
 
 
@@ -17731,13 +18069,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  177 ) # 177. functions.at:1087: FUNCTION PRESENT-VALUE
+  181 ) # 181. functions.at:1087: FUNCTION PRESENT-VALUE
     at_setup_line='functions.at:1087'
     at_desc='FUNCTION PRESENT-VALUE'
-    $at_quiet $ECHO_N "177: FUNCTION PRESENT-VALUE                       $ECHO_C"
+    $at_quiet $ECHO_N "181: FUNCTION PRESENT-VALUE                       $ECHO_C"
     at_xfail=no
     (
-      echo "177. functions.at:1087: testing ..."
+      echo "181. functions.at:1087: testing ..."
       $at_traceon
 
 
@@ -17812,13 +18150,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  178 ) # 178. functions.at:1107: FUNCTION RANGE
+  182 ) # 182. functions.at:1107: FUNCTION RANGE
     at_setup_line='functions.at:1107'
     at_desc='FUNCTION RANGE'
-    $at_quiet $ECHO_N "178: FUNCTION RANGE                               $ECHO_C"
+    $at_quiet $ECHO_N "182: FUNCTION RANGE                               $ECHO_C"
     at_xfail=no
     (
-      echo "178. functions.at:1107: testing ..."
+      echo "182. functions.at:1107: testing ..."
       $at_traceon
 
 
@@ -17893,13 +18231,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  179 ) # 179. functions.at:1127: FUNCTION REM
+  183 ) # 183. functions.at:1127: FUNCTION REM
     at_setup_line='functions.at:1127'
     at_desc='FUNCTION REM'
-    $at_quiet $ECHO_N "179: FUNCTION REM                                 $ECHO_C"
+    $at_quiet $ECHO_N "183: FUNCTION REM                                 $ECHO_C"
     at_xfail=no
     (
-      echo "179. functions.at:1127: testing ..."
+      echo "183. functions.at:1127: testing ..."
       $at_traceon
 
 
@@ -17974,13 +18312,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  180 ) # 180. functions.at:1147: FUNCTION REVERSE
+  184 ) # 184. functions.at:1147: FUNCTION REVERSE
     at_setup_line='functions.at:1147'
     at_desc='FUNCTION REVERSE'
-    $at_quiet $ECHO_N "180: FUNCTION REVERSE                             $ECHO_C"
+    $at_quiet $ECHO_N "184: FUNCTION REVERSE                             $ECHO_C"
     at_xfail=no
     (
-      echo "180. functions.at:1147: testing ..."
+      echo "184. functions.at:1147: testing ..."
       $at_traceon
 
 
@@ -18056,13 +18394,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  181 ) # 181. functions.at:1168: FUNCTION REVERSE with reference modding
+  185 ) # 185. functions.at:1168: FUNCTION REVERSE with reference modding
     at_setup_line='functions.at:1168'
     at_desc='FUNCTION REVERSE with reference modding'
-    $at_quiet $ECHO_N "181: FUNCTION REVERSE with reference modding      $ECHO_C"
+    $at_quiet $ECHO_N "185: FUNCTION REVERSE with reference modding      $ECHO_C"
     at_xfail=no
     (
-      echo "181. functions.at:1168: testing ..."
+      echo "185. functions.at:1168: testing ..."
       $at_traceon
 
 
@@ -18138,13 +18476,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  182 ) # 182. functions.at:1189: FUNCTION SECONDS-FROM-FORMATTED-TIME
+  186 ) # 186. functions.at:1189: FUNCTION SECONDS-FROM-FORMATTED-TIME
     at_setup_line='functions.at:1189'
     at_desc='FUNCTION SECONDS-FROM-FORMATTED-TIME'
-    $at_quiet $ECHO_N "182: FUNCTION SECONDS-FROM-FORMATTED-TIME         $ECHO_C"
+    $at_quiet $ECHO_N "186: FUNCTION SECONDS-FROM-FORMATTED-TIME         $ECHO_C"
     at_xfail=no
     (
-      echo "182. functions.at:1189: testing ..."
+      echo "186. functions.at:1189: testing ..."
       $at_traceon
 
 
@@ -18228,13 +18566,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  183 ) # 183. functions.at:1218: FUNCTION SECONDS-PAST-MIDNIGHT
+  187 ) # 187. functions.at:1218: FUNCTION SECONDS-PAST-MIDNIGHT
     at_setup_line='functions.at:1218'
     at_desc='FUNCTION SECONDS-PAST-MIDNIGHT'
-    $at_quiet $ECHO_N "183: FUNCTION SECONDS-PAST-MIDNIGHT               $ECHO_C"
+    $at_quiet $ECHO_N "187: FUNCTION SECONDS-PAST-MIDNIGHT               $ECHO_C"
     at_xfail=no
     (
-      echo "183. functions.at:1218: testing ..."
+      echo "187. functions.at:1218: testing ..."
       $at_traceon
 
 
@@ -18316,13 +18654,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  184 ) # 184. functions.at:1245: FUNCTION SIGN
+  188 ) # 188. functions.at:1245: FUNCTION SIGN
     at_setup_line='functions.at:1245'
     at_desc='FUNCTION SIGN'
-    $at_quiet $ECHO_N "184: FUNCTION SIGN                                $ECHO_C"
+    $at_quiet $ECHO_N "188: FUNCTION SIGN                                $ECHO_C"
     at_xfail=no
     (
-      echo "184. functions.at:1245: testing ..."
+      echo "188. functions.at:1245: testing ..."
       $at_traceon
 
 
@@ -18406,13 +18744,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  185 ) # 185. functions.at:1274: FUNCTION SIN
+  189 ) # 189. functions.at:1274: FUNCTION SIN
     at_setup_line='functions.at:1274'
     at_desc='FUNCTION SIN'
-    $at_quiet $ECHO_N "185: FUNCTION SIN                                 $ECHO_C"
+    $at_quiet $ECHO_N "189: FUNCTION SIN                                 $ECHO_C"
     at_xfail=no
     (
-      echo "185. functions.at:1274: testing ..."
+      echo "189. functions.at:1274: testing ..."
       $at_traceon
 
 
@@ -18496,13 +18834,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  186 ) # 186. functions.at:1303: FUNCTION SQRT
+  190 ) # 190. functions.at:1303: FUNCTION SQRT
     at_setup_line='functions.at:1303'
     at_desc='FUNCTION SQRT'
-    $at_quiet $ECHO_N "186: FUNCTION SQRT                                $ECHO_C"
+    $at_quiet $ECHO_N "190: FUNCTION SQRT                                $ECHO_C"
     at_xfail=no
     (
-      echo "186. functions.at:1303: testing ..."
+      echo "190. functions.at:1303: testing ..."
       $at_traceon
 
 
@@ -18586,13 +18924,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  187 ) # 187. functions.at:1332: FUNCTION STANDARD-DEVIATION
+  191 ) # 191. functions.at:1332: FUNCTION STANDARD-DEVIATION
     at_setup_line='functions.at:1332'
     at_desc='FUNCTION STANDARD-DEVIATION'
-    $at_quiet $ECHO_N "187: FUNCTION STANDARD-DEVIATION                  $ECHO_C"
+    $at_quiet $ECHO_N "191: FUNCTION STANDARD-DEVIATION                  $ECHO_C"
     at_xfail=no
     (
-      echo "187. functions.at:1332: testing ..."
+      echo "191. functions.at:1332: testing ..."
       $at_traceon
 
 
@@ -18675,13 +19013,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  188 ) # 188. functions.at:1360: FUNCTION STORED-CHAR-LENGTH
+  192 ) # 192. functions.at:1360: FUNCTION STORED-CHAR-LENGTH
     at_setup_line='functions.at:1360'
     at_desc='FUNCTION STORED-CHAR-LENGTH'
-    $at_quiet $ECHO_N "188: FUNCTION STORED-CHAR-LENGTH                  $ECHO_C"
+    $at_quiet $ECHO_N "192: FUNCTION STORED-CHAR-LENGTH                  $ECHO_C"
     at_xfail=no
     (
-      echo "188. functions.at:1360: testing ..."
+      echo "192. functions.at:1360: testing ..."
       $at_traceon
 
 
@@ -18758,13 +19096,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  189 ) # 189. functions.at:1382: FUNCTION SUBSTITUTE
+  193 ) # 193. functions.at:1382: FUNCTION SUBSTITUTE
     at_setup_line='functions.at:1382'
     at_desc='FUNCTION SUBSTITUTE'
-    $at_quiet $ECHO_N "189: FUNCTION SUBSTITUTE                          $ECHO_C"
+    $at_quiet $ECHO_N "193: FUNCTION SUBSTITUTE                          $ECHO_C"
     at_xfail=no
     (
-      echo "189. functions.at:1382: testing ..."
+      echo "193. functions.at:1382: testing ..."
       $at_traceon
 
 
@@ -18841,13 +19179,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  190 ) # 190. functions.at:1404: FUNCTION SUBSTITUTE with reference modding
+  194 ) # 194. functions.at:1404: FUNCTION SUBSTITUTE with reference modding
     at_setup_line='functions.at:1404'
     at_desc='FUNCTION SUBSTITUTE with reference modding'
-    $at_quiet $ECHO_N "190: FUNCTION SUBSTITUTE with reference modding   $ECHO_C"
+    $at_quiet $ECHO_N "194: FUNCTION SUBSTITUTE with reference modding   $ECHO_C"
     at_xfail=no
     (
-      echo "190. functions.at:1404: testing ..."
+      echo "194. functions.at:1404: testing ..."
       $at_traceon
 
 
@@ -18925,13 +19263,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  191 ) # 191. functions.at:1427: FUNCTION SUBSTITUTE-CASE
+  195 ) # 195. functions.at:1427: FUNCTION SUBSTITUTE-CASE
     at_setup_line='functions.at:1427'
     at_desc='FUNCTION SUBSTITUTE-CASE'
-    $at_quiet $ECHO_N "191: FUNCTION SUBSTITUTE-CASE                     $ECHO_C"
+    $at_quiet $ECHO_N "195: FUNCTION SUBSTITUTE-CASE                     $ECHO_C"
     at_xfail=no
     (
-      echo "191. functions.at:1427: testing ..."
+      echo "195. functions.at:1427: testing ..."
       $at_traceon
 
 
@@ -19008,13 +19346,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  192 ) # 192. functions.at:1449: FUNCTION SUBSTITUTE-CASE with reference mod
+  196 ) # 196. functions.at:1449: FUNCTION SUBSTITUTE-CASE with reference mod
     at_setup_line='functions.at:1449'
     at_desc='FUNCTION SUBSTITUTE-CASE with reference mod'
-    $at_quiet $ECHO_N "192: FUNCTION SUBSTITUTE-CASE with reference mod  $ECHO_C"
+    $at_quiet $ECHO_N "196: FUNCTION SUBSTITUTE-CASE with reference mod  $ECHO_C"
     at_xfail=no
     (
-      echo "192. functions.at:1449: testing ..."
+      echo "196. functions.at:1449: testing ..."
       $at_traceon
 
 
@@ -19092,13 +19430,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  193 ) # 193. functions.at:1472: FUNCTION TAN
+  197 ) # 197. functions.at:1472: FUNCTION TAN
     at_setup_line='functions.at:1472'
     at_desc='FUNCTION TAN'
-    $at_quiet $ECHO_N "193: FUNCTION TAN                                 $ECHO_C"
+    $at_quiet $ECHO_N "197: FUNCTION TAN                                 $ECHO_C"
     at_xfail=no
     (
-      echo "193. functions.at:1472: testing ..."
+      echo "197. functions.at:1472: testing ..."
       $at_traceon
 
 
@@ -19182,13 +19520,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  194 ) # 194. functions.at:1501: FUNCTION TRIM
+  198 ) # 198. functions.at:1501: FUNCTION TRIM
     at_setup_line='functions.at:1501'
     at_desc='FUNCTION TRIM'
-    $at_quiet $ECHO_N "194: FUNCTION TRIM                                $ECHO_C"
+    $at_quiet $ECHO_N "198: FUNCTION TRIM                                $ECHO_C"
     at_xfail=no
     (
-      echo "194. functions.at:1501: testing ..."
+      echo "198. functions.at:1501: testing ..."
       $at_traceon
 
 
@@ -19267,13 +19605,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  195 ) # 195. functions.at:1525: FUNCTION TRIM with reference modding
+  199 ) # 199. functions.at:1525: FUNCTION TRIM with reference modding
     at_setup_line='functions.at:1525'
     at_desc='FUNCTION TRIM with reference modding'
-    $at_quiet $ECHO_N "195: FUNCTION TRIM with reference modding         $ECHO_C"
+    $at_quiet $ECHO_N "199: FUNCTION TRIM with reference modding         $ECHO_C"
     at_xfail=no
     (
-      echo "195. functions.at:1525: testing ..."
+      echo "199. functions.at:1525: testing ..."
       $at_traceon
 
 
@@ -19352,13 +19690,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  196 ) # 196. functions.at:1549: FUNCTION UPPER-CASE
+  200 ) # 200. functions.at:1549: FUNCTION UPPER-CASE
     at_setup_line='functions.at:1549'
     at_desc='FUNCTION UPPER-CASE'
-    $at_quiet $ECHO_N "196: FUNCTION UPPER-CASE                          $ECHO_C"
+    $at_quiet $ECHO_N "200: FUNCTION UPPER-CASE                          $ECHO_C"
     at_xfail=no
     (
-      echo "196. functions.at:1549: testing ..."
+      echo "200. functions.at:1549: testing ..."
       $at_traceon
 
 
@@ -19434,13 +19772,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  197 ) # 197. functions.at:1570: FUNCTION UPPER-CASE with reference modding
+  201 ) # 201. functions.at:1570: FUNCTION UPPER-CASE with reference modding
     at_setup_line='functions.at:1570'
     at_desc='FUNCTION UPPER-CASE with reference modding'
-    $at_quiet $ECHO_N "197: FUNCTION UPPER-CASE with reference modding   $ECHO_C"
+    $at_quiet $ECHO_N "201: FUNCTION UPPER-CASE with reference modding   $ECHO_C"
     at_xfail=no
     (
-      echo "197. functions.at:1570: testing ..."
+      echo "201. functions.at:1570: testing ..."
       $at_traceon
 
 
@@ -19516,13 +19854,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  198 ) # 198. functions.at:1591: FUNCTION VARIANCE
+  202 ) # 202. functions.at:1591: FUNCTION VARIANCE
     at_setup_line='functions.at:1591'
     at_desc='FUNCTION VARIANCE'
-    $at_quiet $ECHO_N "198: FUNCTION VARIANCE                            $ECHO_C"
+    $at_quiet $ECHO_N "202: FUNCTION VARIANCE                            $ECHO_C"
     at_xfail=no
     (
-      echo "198. functions.at:1591: testing ..."
+      echo "202. functions.at:1591: testing ..."
       $at_traceon
 
 
@@ -19597,13 +19935,13 @@ $at_traceon
     at_status=`cat $at_status_file`
     ;;
 
-  199 ) # 199. functions.at:1611: FUNCTION WHEN-COMPILED
+  203 ) # 203. functions.at:1611: FUNCTION WHEN-COMPILED
     at_setup_line='functions.at:1611'
     at_desc='FUNCTION WHEN-COMPILED'
-    $at_quiet $ECHO_N "199: FUNCTION WHEN-COMPILED                       $ECHO_C"
+    $at_quiet $ECHO_N "203: FUNCTION WHEN-COMPILED                       $ECHO_C"
     at_xfail=no
     (
-      echo "199. functions.at:1611: testing ..."
+      echo "203. functions.at:1611: testing ..."
       $at_traceon
 
 

--- a/tests/run.src/ref-mod.at
+++ b/tests/run.src/ref-mod.at
@@ -237,3 +237,50 @@ AT_CLEANUP
 
 
 # 6) TODO
+
+AT_SETUP([Offset out of bounds in MOVE (1)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(4) VALUE "abcd".
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X(4).
+       PROCEDURE        DIVISION.
+           MOVE X(I:4) TO Z.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Offset of 'X' out of bounds: 0
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([Offset out of bounds in MOVE (2)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC X(4).
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X(4) VALUE "abcd".
+       PROCEDURE        DIVISION.
+           MOVE Z TO X(I:4).
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Offset of 'X' out of bounds: 0
+])
+
+AT_CLEANUP
+
+# 7) TODO

--- a/tests/run.src/subscripts.at
+++ b/tests/run.src/subscripts.at
@@ -282,3 +282,51 @@ AT_CHECK([${COMPILE} -o prog prog.cob])
 AT_CHECK([./prog], [0], [24])
 
 AT_CLEANUP
+
+
+AT_SETUP([Subscript out of bounds in MOVE (1)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X.
+       PROCEDURE        DIVISION.
+           MOVE X(I) TO Z.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([Subscript out of bounds in MOVE (2)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 9 VALUE 0.
+       01 Z             PIC X.
+       PROCEDURE        DIVISION.
+           MOVE Z TO X(I).
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:11: libcob: Subscript of 'X' out of bounds: 0
+])
+
+AT_CLEANUP


### PR DESCRIPTION
MOVE文の部分参照の境界チェックバグを修正
MOVE文の配列の境界チェックのテストを追加
fixed bug checking reference modification out of bounds for in  MOVE statement.
add tests checking Subscript out of bounds in  MOVE statement.
