### PR TITLE
条件式における項目添字の境界チェックバグを修正

### DIFF
--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -2776,6 +2776,18 @@ cb_build_cond (cb_tree x)
 				x = cb_list_reverse (decimal_stack);
 				decimal_stack = NULL;
 			} else {
+				/* field comparison */
+				if (national_kanji_comparison (p->x, p->y) ||
+				    national_kanji_comparison (p->y, p->x)) {
+					cb_error_x (x, _("Invalid expression test"));
+				}
+
+				if (CB_EXCEPTION_ENABLE (COB_EC_BOUND_SUBSCRIPT)) {
+					/* optim'ed funcs below don't check subscript boundary */
+					x = cb_build_funcall_2 ("cob_cmp", p->x, p->y);
+					break;
+				}
+
 				if (cb_chk_num_cond (p->x, p->y)) {
 					size1 = cb_field_size (p->x);
 					x = cb_build_funcall_3 ("memcmp",
@@ -2789,12 +2801,6 @@ cb_build_cond (cb_tree x)
 				    && cb_fits_int (p->y)) {
 					x = cb_build_optim_cond (p);
 					break;
-				}
-
-				/* field comparison */
-				if (national_kanji_comparison (p->x, p->y) ||
-				    national_kanji_comparison (p->y, p->x)) {
-					cb_error_x (x, _("Invalid expression test"));
 				}
 				if ((CB_REF_OR_FIELD_P (p->x))
 				   && (CB_TREE_CATEGORY (p->x) == CB_CATEGORY_ALPHANUMERIC ||

--- a/tests/run.src/subscripts.at
+++ b/tests/run.src/subscripts.at
@@ -140,6 +140,97 @@ AT_CHECK([./prog], [1], ,
 
 AT_CLEANUP
 
+AT_SETUP([Subscript out of bounds (3-1)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 99 VALUE 11.
+       PROCEDURE        DIVISION.
+           IF "A" NOT = X(I)
+               DISPLAY "DIFFER".
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
+])
+
+AT_CLEANUP
+
+AT_SETUP([Subscript out of bounds (3-2)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC X OCCURS 10.
+       01 I             PIC 99 VALUE 11.
+       PROCEDURE        DIVISION.
+           IF X(I) NOT = "A"
+               DISPLAY "DIFFER".
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
+])
+
+AT_CLEANUP
+
+AT_SETUP([Subscript out of bounds (3-3)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC XX OCCURS 10.
+       01 I             PIC 99 VALUE 11.
+       PROCEDURE        DIVISION.
+           IF X(I) NOT = "AA"
+               DISPLAY "DIFFER".
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
+])
+
+AT_CLEANUP
+
+AT_SETUP([Subscript out of bounds (3-4)])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G.
+         02 X           PIC 9  BINARY OCCURS 10.
+       01 I             PIC 99 VALUE 11.
+       PROCEDURE        DIVISION.
+           IF 5 NOT = X(I)
+               DISPLAY "DIFFER".
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [1], ,
+[prog.cob:10: libcob: Subscript of 'X' out of bounds: 11
+])
+
+AT_CLEANUP
 
 AT_SETUP([Value of DEPENDING ON N out of bounds (lower)])
 


### PR DESCRIPTION
条件式の直接のオペランドとして添字付き項目を書いた場合、実行時チェックのcob_check_subscript()が生成されない場合があります。
項目が特定の条件を満たすとき、コンパイラは（おそらく実行効率の最適化のため）libcob関数を避けてより条件に特化した単純なコードを生成しますが、それらの多くが添字チェックに対応していない模様です。 
そこで、debugオプションが指定され添字チェックが有効のときには、そのようなコード生成を行わず、いつもlibcob関数(cob_cmp)を生成するように変更します。