### PR TITLE
COPY REPLACINGのテストの修正

### DIFF
--- a/tests/jp-compat.src/copy-leading-trailing.at
+++ b/tests/jp-compat.src/copy-leading-trailing.at
@@ -52,7 +52,8 @@ AT_SETUP([COPY REPLACING LEADING TRAILING])
 AT_KEYWORDS([copy])
 
 AT_DATA([copy.inc], [
-       01 LEADER-VAR-TRAILER PIC X(2) VALUE "OK".
+       01 LEADER-VAR         PIC X(2) VALUE "OK".
+       01 VAR-TRAILER        PIC X(2) VALUE "OK".
 ])
 
 AT_DATA([prog.cob], [
@@ -64,9 +65,14 @@ AT_DATA([prog.cob], [
            LEADING  ==LEADER==  BY ==I==
            TRAILING ==TRAILER== BY ==01==.
        PROCEDURE        DIVISION.
-           DISPLAY I-VAR-01 NO ADVANCING
+           DISPLAY I-VAR  NO ADVANCING
+           END-DISPLAY.
+           DISPLAY VAR-01 NO ADVANCING
            END-DISPLAY.
            STOP RUN.
 ])
+
+AT_CHECK([${COMPILE_JP_COMPAT} -o prog prog.cob])
+AT_CHECK([./prog], [0], [OKOK])
 
 AT_CLEANUP


### PR DESCRIPTION
1.3.0Jで追加されたCOPY REPLACINGに対する、テストの修正です。
AT_CHECK追加、および照合置換順序が仕様に対して正しいテストになるよう変更されています。