### PR TITLE
SOURCE FORMAT FREE利用時のコンパイルエラー修正

### DIFF
--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -139,6 +139,14 @@ ALNUM_LITERAL	\"[^\"\n]*\"|\'[^\'\n]*\'
 "END"({ZENSPC}|[ ])+"PROGRAM"		{ ppecho ("END PROGRAM"); return END_PROGRAM; }
 "END"({ZENSPC}|[ ])+"FUNCTION"		{ ppecho ("END FUNCTION"); return END_FUNCTION; }
 
+<*>^"*".* |
+<*>^"/".* {
+	ppecho (" ");
+	if (cb_source_format != CB_FORMAT_FIXED) {
+		ppecho (yytext);
+	}
+}
+
 "PROCESS"		{ BEGIN PROCESS_STATE; }
 
 <PROCESS_STATE>{
@@ -933,13 +941,11 @@ start:
 			newline_count = 0;
 			return strlen (buff);
 		}
-		/*
 		if (n == 0 && cb_source_format != CB_FORMAT_FIXED && cb_source_format1 != 1) {
 			if (ipchar != ' ' && ipchar != '\n') {
 				buff[n++] = ' ';
 			}
 		}
-		*/
 		if (gotcr) {
 			if (ipchar != '\n') {
 				buff[n++] = '\r';
@@ -995,10 +1001,6 @@ start:
 
 	/* nothing more to do with free format */
 	if (cb_source_format != CB_FORMAT_FIXED) {
-		if (buff[0] == '*' || buff[0] == '/') {
-			newline_count++;
-			goto start;
-		}
 		return n;
 	}
 

--- a/cobc/pplex.l.m4
+++ b/cobc/pplex.l.m4
@@ -154,6 +154,14 @@ ALNUM_LITERAL	\"[^\"\n]*\"|\'[^\'\n]*\'
 "END"({ZENSPC}|[ ])+"PROGRAM"		{ ppecho ("END PROGRAM"); return END_PROGRAM; }
 "END"({ZENSPC}|[ ])+"FUNCTION"		{ ppecho ("END FUNCTION"); return END_FUNCTION; }
 
+<*>^"*".* |
+<*>^"/".* {
+	ppecho (" ");
+	if (cb_source_format != CB_FORMAT_FIXED) {
+		ppecho (yytext);
+	}
+}
+
 "PROCESS"		{ BEGIN PROCESS_STATE; }
 
 <PROCESS_STATE>{
@@ -948,13 +956,11 @@ start:
 			newline_count = 0;
 			return strlen (buff);
 		}
-		/*
 		if (n == 0 && cb_source_format != CB_FORMAT_FIXED && cb_source_format1 != 1) {
 			if (ipchar != ' ' && ipchar != '\n') {
 				buff[n++] = ' ';
 			}
 		}
-		*/
 		if (gotcr) {
 			if (ipchar != '\n') {
 				buff[n++] = '\r';
@@ -1010,10 +1016,6 @@ start:
 
 	/* nothing more to do with free format */
 	if (cb_source_format != CB_FORMAT_FIXED) {
-		if (buff[0] == '*' || buff[0] == '/') {
-			newline_count++;
-			goto start;
-		}
 		return n;
 	}
 


### PR DESCRIPTION
opensource COBOL1.3.2Jにおいて、以下の条件で発生する不正なコンパイルエラーの対策です。

1. ソース中で">>SOURCE FORMAT FREE"を指定する
2. FREEフォーマット中でコメントを6行以上記載する
3. ">>SOURCE FORMAT FIXED"を指定する

OpenCOBOL CE r54 のマージ更新 13c73d894d065da0373e5f88f0a8b331c520df1e において矛盾する変更を加えてしまっていたので、これを取り消すことによって本件の問題を修正します。 