### PR TITLE
REPLACE文がCOPY REPLACING以降で無効になる問題の修正

### DIFF
--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -297,6 +297,7 @@ extern int	ppparse (void);
 extern int	ppopen (const char *name, struct cb_joining_ext *joining_ext, struct cb_replace_list *replace_list);
 extern int	ppcopy (const char *name, const char *lib, struct cb_joining_ext *joining_ext, struct cb_replace_list *replace_list);
 extern void	pp_set_replace_list (struct cb_replace_list *replace_list);
+extern void	pp_set_copy_replace_list (struct cb_replace_list *replace_list);
 extern void	pp_set_joining_ext (struct cb_joining_ext *joining_ext);
 
 #define PP_OUT_OF_DIVISION		0

--- a/tests/syntax.src/copy.at
+++ b/tests/syntax.src/copy.at
@@ -153,3 +153,30 @@ AT_CHECK([${COMPILE} -o prog prog.cob])
 AT_CHECK([./prog], [0], [OK])
 
 AT_CLEANUP
+
+
+AT_SETUP([COPY: after REPLACE])
+
+AT_DATA([copy_rep01.inc], [
+       01 WK-02          PIC X(2) value SP.
+])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       REPLACE 'AA' BY 'ZZ'.
+       01 WK-01          PIC X(2) VALUE 'AA'.
+       COPY "copy_rep01.inc" REPLACING SP by space.
+       01 WK-03          PIC X(2) VALUE 'AA'.
+       PROCEDURE        DIVISION.
+           DISPLAY WK-01 WK-02 WK-03 NO ADVANCING
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([./prog], [0], [ZZ  ZZ])
+
+AT_CLEANUP


### PR DESCRIPTION
COBOLプログラムにおいてREPLACE文で置き換えを指定しており、その後COPY REPLACING文が出現すると、それ以降でREPLACEの効果が無効になる問題の修正です。