### PR TITLE
 シンボル曖昧参照エラー表示の節・段落名誤り修正

### DIFF
--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -793,6 +793,8 @@ start:
   /* program_definition */
   nested_list TOKEN_EOF
   {
+	current_section = NULL;
+	current_paragraph = NULL;
 	if (!current_program->flag_validated) {
 		current_program->flag_validated = 1;
 		cb_validate_program_body (current_program);
@@ -855,6 +857,8 @@ end_program:
   {
 	char			*s;
 
+	current_section = NULL;
+	current_paragraph = NULL;
 	if (CB_LITERAL_P ($2)) {
 		s = (char *)(CB_LITERAL ($2)->data);
 	} else {
@@ -881,6 +885,8 @@ end_mandatory:
   {
 	char			*s;
 
+	current_section = NULL;
+	current_paragraph = NULL;
 	if (CB_LITERAL_P ($2)) {
 		s = (char *)(CB_LITERAL ($2)->data);
 	} else {
@@ -905,6 +911,8 @@ end_function:
   {
 	char			*s;
 
+	current_section = NULL;
+	current_paragraph = NULL;
 	if (CB_LITERAL_P ($2)) {
 		s = (char *)(CB_LITERAL ($2)->data);
 	} else {

--- a/tests/syntax.src/definition.at
+++ b/tests/syntax.src/definition.at
@@ -410,6 +410,27 @@ AT_CHECK([${COMPILE_ONLY} prog.cob], [0])
 AT_CLEANUP
 
 
+AT_SETUP([Omit para/sect label names in ref check msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       PROCEDURE        DIVISION.
+         L0. GO TO L1.
+         L1. GOBACK.
+         L1. GOBACK.
+         L2. STOP RUN.
+])
+
+AT_CHECK([${COMPILE_ONLY} prog.cob], [1], ,
+[prog.cob:6: Error: 'L1' ambiguous; need qualification
+prog.cob:7: Error: 'L1' in 'MAIN SECTION' defined here
+prog.cob:8: Error: 'L1' in 'MAIN SECTION' defined here
+])
+
+AT_CLEANUP
+
 ###
 ### File name
 ###
@@ -517,8 +538,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE_ONLY} prog.cob], [1], ,
-[prog.cob: In section 'S-3':
-prog.cob:10: Error: 'L' ambiguous; need qualification
+[prog.cob:10: Error: 'L' ambiguous; need qualification
 prog.cob:6: Error: 'L' in 'S-1' defined here
 prog.cob:8: Error: 'L' in 'S-2' defined here
 ])


### PR DESCRIPTION
曖昧な節・段落参照があったときのコンパイルエラーメッセージで、同時に表示される'In paragraph...'や'In section...'が正しくなく、常に手続き部の最後の節・段落が表示されてしまう問題の修正です。