### PR TITLE
実行時およびコンパイル時メッセージの日本語項目名等の文字化け修正

### DIFF
--- a/cobc/error.c
+++ b/cobc/error.c
@@ -341,6 +341,17 @@ redefinition_warning (cb_tree x, cb_tree y)
 	}
 }
 
+#define jisword_cat(w, buf, len) {					\
+		size_t n = strnlen ((buf), (len));			\
+		cb_get_jisword_buff ((w), &((buf)[n]), (len) + 1 - n);	\
+	}
+
+#define jisword_quote(w, buf, len) {					\
+		strncpy ((buf), "'", (len));				\
+		cb_get_jisword_buff ((w), &((buf)[1]), (len));		\
+		strncat ((buf), "'", (len));				\
+	}
+
 void
 undefined_error (cb_tree x)
 {
@@ -351,11 +362,11 @@ undefined_error (cb_tree x)
 		errnamebuff = cobc_malloc (COB_NORMAL_BUFF);
 	}
 	r = CB_REFERENCE (x);
-	snprintf (errnamebuff, COB_NORMAL_MAX, "'%s'", CB_NAME (x));
+	jisword_quote (CB_NAME (x), errnamebuff, COB_NORMAL_MAX);
 	for (c = r->chain; c; c = CB_REFERENCE (c)->chain) {
-		strcat (errnamebuff, " in '");
-		strcat (errnamebuff, CB_NAME (c));
-		strcat (errnamebuff, "'");
+		strncat (errnamebuff, " in '", COB_NORMAL_MAX);
+		jisword_cat (CB_NAME (c), errnamebuff, COB_NORMAL_MAX);
+		strncat (errnamebuff, "'", COB_NORMAL_MAX);
 	}
 	cb_error_x (x, _("%s undefined"), errnamebuff);
 }
@@ -375,11 +386,11 @@ ambiguous_error (cb_tree x)
 			errnamebuff = cobc_malloc (COB_NORMAL_BUFF);
 		}
 		/* display error on the first time */
-		snprintf (errnamebuff, COB_NORMAL_MAX, "'%s'", CB_NAME (x));
+		jisword_quote (CB_NAME (x), errnamebuff, COB_NORMAL_MAX);
 		for (l = CB_REFERENCE (x)->chain; l; l = CB_REFERENCE (l)->chain) {
-			strcat (errnamebuff, " in '");
-			strcat (errnamebuff, CB_NAME (l));
-			strcat (errnamebuff, "'");
+			strncat (errnamebuff, " in '", COB_NORMAL_MAX);
+			jisword_cat (CB_NAME (l), errnamebuff, COB_NORMAL_MAX);
+			strncat (errnamebuff, "'", COB_NORMAL_MAX);
 		}
 		cb_error_x (x, _("%s ambiguous; need qualification"), errnamebuff);
 		w->error = 1;
@@ -387,27 +398,29 @@ ambiguous_error (cb_tree x)
 		/* display all fields with the same name */
 		for (l = w->items; l; l = CB_CHAIN (l)) {
 			y = CB_VALUE (l);
-			snprintf (errnamebuff, COB_NORMAL_MAX, "'%s' ", w->name);
+			jisword_quote (w->name, errnamebuff, COB_NORMAL_MAX);
 			switch (CB_TREE_TAG (y)) {
 			case CB_TAG_FIELD:
 				for (p = CB_FIELD (y)->parent; p; p = p->parent) {
-					strcat (errnamebuff, "in '");
-					strcat (errnamebuff, check_filler_name((char *)p->name));
-					strcat (errnamebuff, "' ");
+					strncat (errnamebuff, " in '", COB_NORMAL_MAX);
+					jisword_cat (check_filler_name((char *)p->name),
+						     errnamebuff, COB_NORMAL_MAX);
+					strncat (errnamebuff, "'", COB_NORMAL_MAX);
 				}
 				break;
 			case CB_TAG_LABEL:
 				l2 = CB_LABEL (y);
 				if (l2->section) {
-					strcat (errnamebuff, "in '");
-					strcat (errnamebuff, (const char *)(l2->section->name));
-					strcat (errnamebuff, "' ");
+					strncat (errnamebuff, " in '", COB_NORMAL_MAX);
+					jisword_cat ((const char *)(l2->section->name),
+						     errnamebuff, COB_NORMAL_MAX);
+					strncat (errnamebuff, "'", COB_NORMAL_MAX);
 				}
 				break;
 			default:
 				break;
 			}
-			strcat (errnamebuff, _("defined here"));
+			strcat (errnamebuff, _(" defined here"));
 			cb_error_x (y, errnamebuff);
 		}
 	}

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1614,8 +1614,11 @@ cob_table_sort (cob_field *f, const int n)
 void
 cob_check_based (const unsigned char *x, const char *name)
 {
+	char	msgword[COB_MINI_BUFF];
+
 	if (!x) {
-		cob_runtime_error ("BASED/LINKAGE item '%s' has NULL address", name);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("BASED/LINKAGE item '%s' has NULL address", msgword);
 		cob_stop_run (1);
 	}
 }
@@ -1627,6 +1630,7 @@ cob_check_numeric (const cob_field *f, const char *name)
 	char		*p;
 	char		*buff;
 	size_t		i;
+	char		msgword[COB_MINI_BUFF];
 
 	if (!cob_is_numeric (f)) {
 		buff = cob_malloc (COB_SMALL_BUFF);
@@ -1640,7 +1644,8 @@ cob_check_numeric (const cob_field *f, const char *name)
 			}
 		}
 		*p = '\0';
-		cob_runtime_error ("'%s' not numeric: '%s'", name, buff);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("'%s' not numeric: '%s'", msgword, buff);
 		cob_stop_run (1);
 	}
 }
@@ -1648,10 +1653,13 @@ cob_check_numeric (const cob_field *f, const char *name)
 void
 cob_check_odo (const int i, const int min, const int max, const char *name)
 {
+	char	msgword[COB_MINI_BUFF];
+
 	/* check the OCCURS DEPENDING ON item */
 	if (i < min || max < i) {
 		cob_set_exception (COB_EC_BOUND_ODO);
-		cob_runtime_error ("OCCURS DEPENDING ON '%s' out of bounds: %d", name, i);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("OCCURS DEPENDING ON '%s' out of bounds: %d", msgword, i);
 		cob_stop_run (1);
 	}
 }
@@ -1659,10 +1667,13 @@ cob_check_odo (const int i, const int min, const int max, const char *name)
 void
 cob_check_subscript (const int i, const int min, const int max, const char *name)
 {
+	char	msgword[COB_MINI_BUFF];
+
 	/* check the subscript */
 	if (i < min || max < i) {
 		cob_set_exception (COB_EC_BOUND_SUBSCRIPT);
-		cob_runtime_error ("Subscript of '%s' out of bounds: %d", name, i);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("Subscript of '%s' out of bounds: %d", msgword, i);
 		cob_stop_run (1);
 	}
 }
@@ -1686,6 +1697,8 @@ cob_check_env (const char *name, const char *value)
 void
 cob_check_ref_mod_national (int offset, int length, int size, const char *name)
 {
+	char	msgword[COB_MINI_BUFF];
+
 	if (cob_check_env (NAMERMCHECK, VALUERMCHECK)) {
 		return;
 	}
@@ -1702,14 +1715,16 @@ cob_check_ref_mod_national (int offset, int length, int size, const char *name)
 
 	if (offset < 1 || offset > size) {
 		cob_set_exception (COB_EC_BOUND_REF_MOD);
-		cob_runtime_error ("Offset of '%s' out of bounds: %d", name, offset);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("Offset of '%s' out of bounds: %d", msgword, offset);
 		cob_stop_run (1);
 	}
 
 	/* check the length */
 	if (length < 1 || offset + length - 1 > size) {
 		cob_set_exception (COB_EC_BOUND_REF_MOD);
-		cob_runtime_error ("Length of '%s' out of bounds: %d", name, length);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("Length of '%s' out of bounds: %d", msgword, length);
 		cob_stop_run (1);
 	}
 }
@@ -1717,20 +1732,24 @@ cob_check_ref_mod_national (int offset, int length, int size, const char *name)
 void
 cob_check_ref_mod (const int offset, const int length, const int size, const char *name)
 {
+	char	msgword[COB_MINI_BUFF];
+
 	if (cob_check_env (NAMERMCHECK, VALUERMCHECK)) {
 		return;
 	}
 	/* check the offset */
 	if (offset < 1 || offset > size) {
 		cob_set_exception (COB_EC_BOUND_REF_MOD);
-		cob_runtime_error ("Offset of '%s' out of bounds: %d", name, offset);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("Offset of '%s' out of bounds: %d", msgword, offset);
 		cob_stop_run (1);
 	}
 
 	/* check the length */
 	if (length < 1 || offset + length - 1 > size) {
 		cob_set_exception (COB_EC_BOUND_REF_MOD);
-		cob_runtime_error ("Length of '%s' out of bounds: %d", name, length);
+		cb_get_jisword_buff (name, msgword, sizeof (msgword));
+		cob_runtime_error ("Length of '%s' out of bounds: %d", msgword, length);
 		cob_stop_run (1);
 	}
 }
@@ -1738,14 +1757,16 @@ cob_check_ref_mod (const int offset, const int length, const int size, const cha
 unsigned char *
 cob_external_addr (const char *exname, const int exlength)
 {
-	static struct cob_external *basext = NULL;
-	struct cob_external *eptr;
+	static struct cob_external	*basext = NULL;
+	struct cob_external		*eptr;
+	char				msgword[COB_MINI_BUFF];
 
 	for (eptr = basext; eptr; eptr = eptr->next) {
 		if (!strcmp (exname, eptr->ename)) {
 			if (exlength > eptr->esize) {
+				cb_get_jisword_buff (exname, msgword, sizeof (msgword));
 				cob_runtime_error ("EXTERNAL item '%s' has size > %d",
-						   exname, exlength);
+						   msgword, exlength);
 				cob_stop_run (1);
 			}
 			cob_initial_external = 0;

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -381,3 +381,105 @@ AT_CHECK([./prog], [1], [],
 
 AT_CLEANUP
 
+AT_SETUP([Nihongo field name in undefined error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G集団項目.
+          03 A項目 PIC X.
+       PROCEDURE        DIVISION.
+001009     DISPLAY NO-FLD.
+001010     DISPLAY NO-FLD IN G-GRP.
+001011     DISPLAY NO-FLD IN NO-GRP.
+001012     DISPLAY NO項目.
+001013     DISPLAY NO項目 IN G集団項目.
+001014     DISPLAY NO項目 IN NO集団項目.
+001015     DISPLAY NO-FLD IN G集団項目.
+001016     DISPLAY NO-FLD IN NO集団項目.
+001017     DISPLAY NO項目 IN G-GRP.
+001018     DISPLAY NO項目 IN NO-GRP.
+001019     DISPLAY NO項目 IN G集団項目 IN NO集団項目.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob], [1], [],
+[prog.cob:9: Error: 'NO-FLD' undefined
+prog.cob:10: Error: 'NO-FLD' in 'G-GRP' undefined
+prog.cob:11: Error: 'NO-FLD' in 'NO-GRP' undefined
+prog.cob:12: Error: 'NO項目' undefined
+prog.cob:13: Error: 'NO項目' in 'G集団項目' undefined
+prog.cob:14: Error: 'NO項目' in 'NO集団項目' undefined
+prog.cob:15: Error: 'NO-FLD' in 'G集団項目' undefined
+prog.cob:16: Error: 'NO-FLD' in 'NO集団項目' undefined
+prog.cob:17: Error: 'NO項目' in 'G-GRP' undefined
+prog.cob:18: Error: 'NO項目' in 'NO-GRP' undefined
+prog.cob:19: Error: 'NO項目' in 'G集団項目' in 'NO集団項目' undefined
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in ambiguous error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 A項目 PIC X.
+       01 G1集団.
+          03 A項目 PIC X.
+          03 B項目 PIC X.
+          03 G2集団.
+             05 A項目 PIC X.
+             05 B項目 PIC X.
+       PROCEDURE        DIVISION.
+001014     DISPLAY A項目.
+001015     DISPLAY B項目 IN G1集団.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE_ONLY} prog.cob], [1], [],
+[prog.cob:8: Warning: Redefinition of 'A項目'
+prog.cob:6: Warning: 'A項目' previously defined here
+prog.cob:11: Warning: Redefinition of 'A項目'
+prog.cob:6: Warning: 'A項目' previously defined here
+prog.cob:14: Error: 'A項目' ambiguous; need qualification
+prog.cob:6: Error: 'A項目' defined here
+prog.cob:8: Error: 'A項目' in 'G1集団' defined here
+prog.cob:11: Error: 'A項目' in 'G2集団' in 'G1集団' defined here
+prog.cob:15: Error: 'B項目' in 'G1集団' ambiguous; need qualification
+prog.cob:9: Error: 'B項目' in 'G1集団' defined here
+prog.cob:12: Error: 'B項目' in 'G2集団' in 'G1集団' defined here
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo label name in ambiguous error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       PROCEDURE        DIVISION.
+001006   L0見出し.
+001007     GO TO L1見出し.
+001008     GO TO L2見出し IN S1節.
+001009   L1見出し. GOBACK.
+001010   L1見出し. GOBACK.
+001011 S1節             SECTION.
+001012   L2見出し. GOBACK.
+001013   L2見出し. GOBACK.
+])
+
+AT_CHECK([${COMPILE_ONLY} prog.cob], [1], [],
+[prog.cob:7: Error: 'L1見出し' ambiguous; need qualification
+prog.cob:9: Error: 'L1見出し' in 'MAIN SECTION' defined here
+prog.cob:10: Error: 'L1見出し' in 'MAIN SECTION' defined here
+prog.cob:8: Error: 'L2見出し' in 'S1節' ambiguous; need qualification
+prog.cob:12: Error: 'L2見出し' in 'S1節' defined here
+prog.cob:13: Error: 'L2見出し' in 'S1節' defined here
+])
+
+AT_CLEANUP

--- a/tests/i18n_sjis.src/user-defined-word.at
+++ b/tests/i18n_sjis.src/user-defined-word.at
@@ -123,7 +123,8 @@ AT_SETUP([Too long section name])
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      prog.
-       DATA             DIVISION.       WORKING-STORAGE  SECTION.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
        PROCEDURE        DIVISION.
        PERFORM s‚P‚Q‚R‚S‚T‚U‚V‚W‚X‚O123456789012345678901.
        PERFORM    ‚r|I—¹.
@@ -135,8 +136,8 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([${COMPILE} -x prog.cob], [1], [],
-[prog.cob:6: Error: User defined name must be less than 32 characters
-prog.cob:8: Error: User defined name must be less than 32 characters
+[prog.cob:7: Error: User defined name must be less than 32 characters
+prog.cob:9: Error: User defined name must be less than 32 characters
 ])
 
 AT_CLEANUP
@@ -175,3 +176,208 @@ AT_CHECK([${COMPILE} -x prog.cob])
 AT_CHECK([./prog], [0], [OK])
 
 AT_CLEANUP
+
+AT_SETUP([Nihongo field name in numeric test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       numcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  TEST-REC.
+         03  U€–Ú  PIC  9(4) VALUE  1000.
+       01  X€–Ú    PIC  X(4) VALUE 'ABCD'.
+       PROCEDURE         DIVISION.
+           MOVE X€–Ú TO TEST-REC.
+           ADD 1 TO U€–Ú.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:11: libcob: 'U€–Ú' not numeric: 'ABCD'
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in BASED test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       basedcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X€–Ú    PIC  X(4) VALUE 'ABCD'.
+       01  Y€–Ú    PIC  X(4) BASED.
+       PROCEDURE         DIVISION.
+           MOVE X€–Ú TO Y€–Ú.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:9: libcob: BASED/LINKAGE item 'Y€–Ú' has NULL address
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in ODO test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       odocheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I€–Ú         PIC 9 VALUE 4.
+       01  X.
+         03  Y€–Ú       PIC 9 OCCURS 1 TO 3 DEPENDING ON I€–Ú.
+       PROCEDURE         DIVISION.
+           MOVE 1 TO Y€–Ú(3).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: OCCURS DEPENDING ON 'I€–Ú' out of bounds: 4
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in Subscript test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       odocheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I€–Ú         PIC 9 VALUE 2.
+       01  X.
+         03  Y€–Ú       PIC 9 OCCURS 1 TO 3 DEPENDING ON I€–Ú.
+       PROCEDURE         DIVISION.
+           MOVE 1 TO Y€–Ú(3).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Subscript of 'Y€–Ú' out of bounds: 3
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in length of ref_mod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 2.
+       01  J             PIC 9    VALUE 6.
+       01  X€–Ú         PIC X(5) VALUE "ABCDE".
+       PROCEDURE         DIVISION.
+           DISPLAY X€–Ú(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Length of 'X€–Ú' out of bounds: 6
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in offset of ref_mod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 6.
+       01  J             PIC 9    VALUE 2.
+       01  X€–Ú         PIC X(5) VALUE "ABCDE".
+       PROCEDURE         DIVISION.
+           DISPLAY X€–Ú(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Offset of 'X€–Ú' out of bounds: 6
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in length of N_refmod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 2.
+       01  J             PIC 99   VALUE 18.
+       01  X€–Ú         PIC N(5) VALUE "‚`‚a‚b‚c‚d".
+       PROCEDURE         DIVISION.
+           DISPLAY X€–Ú(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Length of 'X€–Ú' out of bounds: 18
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in offset of N_refmod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 99   VALUE 18.
+       01  J             PIC 9    VALUE 2.
+       01  X€–Ú         PIC N(5) VALUE "‚`‚a‚b‚c‚d".
+       PROCEDURE         DIVISION.
+           DISPLAY X€–Ú(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Offset of 'X€–Ú' out of bounds: 18
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in extaddr test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       check1.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X€–Ú         PIC X(5) EXTERNAL.
+       PROCEDURE         DIVISION.
+           CALL 'check2'.
+
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       check2.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X€–Ú         PIC X(6) EXTERNAL.
+       PROCEDURE         DIVISION.
+           END PROGRAM check2.
+           END PROGRAM check1.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:8: libcob: EXTERNAL item 'X€–Ú' has size > 6
+])
+
+AT_CLEANUP
+

--- a/tests/i18n_utf8.src/user-defined-word.at
+++ b/tests/i18n_utf8.src/user-defined-word.at
@@ -176,3 +176,208 @@ AT_CHECK([${COMPILE} -x prog.cob])
 AT_CHECK([./prog], [0], [OK])
 
 AT_CLEANUP
+
+AT_SETUP([Nihongo field name in numeric test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       numcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  TEST-REC.
+         03  U項目  PIC  9(4) VALUE  1000.
+       01  X項目    PIC  X(4) VALUE 'ABCD'.
+       PROCEDURE         DIVISION.
+           MOVE X項目 TO TEST-REC.
+           ADD 1 TO U項目.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:11: libcob: 'U項目' not numeric: 'ABCD'
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in BASED test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       basedcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X項目    PIC  X(4) VALUE 'ABCD'.
+       01  Y項目    PIC  X(4) BASED.
+       PROCEDURE         DIVISION.
+           MOVE X項目 TO Y項目.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:9: libcob: BASED/LINKAGE item 'Y項目' has NULL address
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in ODO test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       odocheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I項目         PIC 9 VALUE 4.
+       01  X.
+         03  Y項目       PIC 9 OCCURS 1 TO 3 DEPENDING ON I項目.
+       PROCEDURE         DIVISION.
+           MOVE 1 TO Y項目(3).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: OCCURS DEPENDING ON 'I項目' out of bounds: 4
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in Subscript test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       odocheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I項目         PIC 9 VALUE 2.
+       01  X.
+         03  Y項目       PIC 9 OCCURS 1 TO 3 DEPENDING ON I項目.
+       PROCEDURE         DIVISION.
+           MOVE 1 TO Y項目(3).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Subscript of 'Y項目' out of bounds: 3
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in length of ref_mod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 2.
+       01  J             PIC 9    VALUE 6.
+       01  X項目         PIC X(5) VALUE "ABCDE".
+       PROCEDURE         DIVISION.
+           DISPLAY X項目(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Length of 'X項目' out of bounds: 6
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in offset of ref_mod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 6.
+       01  J             PIC 9    VALUE 2.
+       01  X項目         PIC X(5) VALUE "ABCDE".
+       PROCEDURE         DIVISION.
+           DISPLAY X項目(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Offset of 'X項目' out of bounds: 6
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in length of N_refmod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 9    VALUE 2.
+       01  J             PIC 99   VALUE 18.
+       01  X項目         PIC N(5) VALUE "ＡＢＣＤＥ".
+       PROCEDURE         DIVISION.
+           DISPLAY X項目(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Length of 'X項目' out of bounds: 18
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in offset of N_refmod test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       refcheck.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  I             PIC 99   VALUE 18.
+       01  J             PIC 9    VALUE 2.
+       01  X項目         PIC N(5) VALUE "ＡＢＣＤＥ".
+       PROCEDURE         DIVISION.
+           DISPLAY X項目(I:J).
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:10: libcob: Offset of 'X項目' out of bounds: 18
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in extaddr test msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       check1.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X項目         PIC X(5) EXTERNAL.
+       PROCEDURE         DIVISION.
+           CALL 'check2'.
+
+       IDENTIFICATION    DIVISION.
+       PROGRAM-ID.       check2.
+       DATA              DIVISION.
+       WORKING-STORAGE   SECTION.
+       01  X項目         PIC X(6) EXTERNAL.
+       PROCEDURE         DIVISION.
+           END PROGRAM check2.
+           END PROGRAM check1.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob])
+AT_CHECK([./prog], [1], [],
+[prog.cob:8: libcob: EXTERNAL item 'X項目' has size > 6
+])
+
+AT_CLEANUP
+

--- a/tests/i18n_utf8.src/user-defined-word.at
+++ b/tests/i18n_utf8.src/user-defined-word.at
@@ -381,3 +381,105 @@ AT_CHECK([./prog], [1], [],
 
 AT_CLEANUP
 
+AT_SETUP([Nihongo field name in undefined error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 G集団項目.
+          03 A項目 PIC X.
+       PROCEDURE        DIVISION.
+001009     DISPLAY NO-FLD.
+001010     DISPLAY NO-FLD IN G-GRP.
+001011     DISPLAY NO-FLD IN NO-GRP.
+001012     DISPLAY NO項目.
+001013     DISPLAY NO項目 IN G集団項目.
+001014     DISPLAY NO項目 IN NO集団項目.
+001015     DISPLAY NO-FLD IN G集団項目.
+001016     DISPLAY NO-FLD IN NO集団項目.
+001017     DISPLAY NO項目 IN G-GRP.
+001018     DISPLAY NO項目 IN NO-GRP.
+001019     DISPLAY NO項目 IN G集団項目 IN NO集団項目.
+])
+
+AT_CHECK([${COMPILE} -debug -x prog.cob], [1], [],
+[prog.cob:9: Error: 'NO-FLD' undefined
+prog.cob:10: Error: 'NO-FLD' in 'G-GRP' undefined
+prog.cob:11: Error: 'NO-FLD' in 'NO-GRP' undefined
+prog.cob:12: Error: 'NO項目' undefined
+prog.cob:13: Error: 'NO項目' in 'G集団項目' undefined
+prog.cob:14: Error: 'NO項目' in 'NO集団項目' undefined
+prog.cob:15: Error: 'NO-FLD' in 'G集団項目' undefined
+prog.cob:16: Error: 'NO-FLD' in 'NO集団項目' undefined
+prog.cob:17: Error: 'NO項目' in 'G-GRP' undefined
+prog.cob:18: Error: 'NO項目' in 'NO-GRP' undefined
+prog.cob:19: Error: 'NO項目' in 'G集団項目' in 'NO集団項目' undefined
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo field name in ambiguous error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 A項目 PIC X.
+       01 G1集団.
+          03 A項目 PIC X.
+          03 B項目 PIC X.
+          03 G2集団.
+             05 A項目 PIC X.
+             05 B項目 PIC X.
+       PROCEDURE        DIVISION.
+001014     DISPLAY A項目.
+001015     DISPLAY B項目 IN G1集団.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE_ONLY} prog.cob], [1], [],
+[prog.cob:8: Warning: Redefinition of 'A項目'
+prog.cob:6: Warning: 'A項目' previously defined here
+prog.cob:11: Warning: Redefinition of 'A項目'
+prog.cob:6: Warning: 'A項目' previously defined here
+prog.cob:14: Error: 'A項目' ambiguous; need qualification
+prog.cob:6: Error: 'A項目' defined here
+prog.cob:8: Error: 'A項目' in 'G1集団' defined here
+prog.cob:11: Error: 'A項目' in 'G2集団' in 'G1集団' defined here
+prog.cob:15: Error: 'B項目' in 'G1集団' ambiguous; need qualification
+prog.cob:9: Error: 'B項目' in 'G1集団' defined here
+prog.cob:12: Error: 'B項目' in 'G2集団' in 'G1集団' defined here
+])
+
+AT_CLEANUP
+
+AT_SETUP([Nihongo label name in ambiguous error msg.])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       PROCEDURE        DIVISION.
+001006   L0見出し.
+001007     GO TO L1見出し.
+001008     GO TO L2見出し IN S1節.
+001009   L1見出し. GOBACK.
+001010   L1見出し. GOBACK.
+001011 S1節             SECTION.
+001012   L2見出し. GOBACK.
+001013   L2見出し. GOBACK.
+])
+
+AT_CHECK([${COMPILE_ONLY} prog.cob], [1], [],
+[prog.cob:7: Error: 'L1見出し' ambiguous; need qualification
+prog.cob:9: Error: 'L1見出し' in 'MAIN SECTION' defined here
+prog.cob:10: Error: 'L1見出し' in 'MAIN SECTION' defined here
+prog.cob:8: Error: 'L2見出し' in 'S1節' ambiguous; need qualification
+prog.cob:12: Error: 'L2見出し' in 'S1節' defined here
+prog.cob:13: Error: 'L2見出し' in 'S1節' defined here
+])
+
+AT_CLEANUP


### PR DESCRIPTION
いくつかの実行時およびコンパイル時メッセージに含まれる項目名などのSJIS/Unicode語が、内部表現である数字列で表示されてしまう問題の修正です。