### PR TITLE
gcc5でmake checkが失敗する件の修正

### DIFF
--- a/libcob.h
+++ b/libcob.h
@@ -37,6 +37,7 @@ extern "C" {
 #include <libcob/strings.h>
 #include <libcob/termio.h>
 #include <libcob/intrinsic.h>
+#include <libcob/codegen.h>
 
 #ifdef __cplusplus
 }

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -215,6 +215,7 @@ struct dirent		*listdir_filedata;
 #define        READOPTSSIZE  4
 #define        STARTCONDSIZE 2
 #define        EXCPTCODESIZE 6
+#define        FNSTATUSSIZE  3
 
 cob_file		*cob_error_file;
 
@@ -4120,7 +4121,7 @@ cob_invoke_fun (int operate, char *f, cob_field *key, char *rec,
 	char	oper[OPENMODESIZE];
 	char	excpcode[EXCPTCODESIZE];
 	char	*p_excpcode = excpcode;
-	char	tmpfnstatus[2];
+	char	tmpfnstatus[FNSTATUSSIZE];
 	char	*p_tmpfnstatus = tmpfnstatus;
 	int		status1 = 0;
 	int	(*funcint)();

--- a/libcob/numeric.c
+++ b/libcob/numeric.c
@@ -30,11 +30,9 @@
 /* Force symbol exports */
 #define	COB_LIB_EXPIMP
 
+#define	COB_LIB_INCLUDE
 #include "libcob.h"
 #include "coblocal.h"
-
-#define	COB_LIB_INCLUDE
-#include "codegen.h"
 
 #define DECIMAL_NAN	-128
 #define DECIMAL_CHECK(d1,d2) \


### PR DESCRIPTION
cobcが生成するCコードについて、gccでのコンパイル時に一部の関数の宣言がなくて警告が出るせいでテストが失敗する件を修正しました。libcob.hに当該関数を宣言するヘッダを追加しています。
