### PR TITLE
コンパイルオプションの文字列連結を修正

### DIFF
--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -1168,7 +1168,7 @@ process_command_line (const int argc, char *argv[])
 #ifdef _MSC_VER
 			strcat (cob_define_flags, "/I ");
 #else
-			strcat (cob_define_flags, "-I");
+			strcat (cob_define_flags, " -I");
 #endif
 			strcat (cob_define_flags, "\"");
 			strcat (cob_define_flags, optarg);


### PR DESCRIPTION
コンパイル時にオプションが複数ある場合に[-I]のオプションが前のオプションとつながってしまう問題を発見しました。

ご確認をお願いします。