### PR TITLE
複数プログラム実行時のCANCEL ALLに関する問題 / Problems with CANCEL ALL when running multiple programs

### DIFF
--- a/libcob/call.c
+++ b/libcob/call.c
@@ -316,10 +316,8 @@ cob_cancel_call_stack_list (struct call_stack_list *p)
 	if (p->children) {
 		cob_cancel_call_stack_list (p->children);
 	}
-	struct call_stack_list *s = p->sister;
-	while (s != NULL) {
-		cob_cancel_call_stack_list (s);
-		s = s->sister;
+	if (p->sister) {
+		cob_cancel_call_stack_list (p->sister);
 	}
 }
 

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -768,7 +768,7 @@ cob_push_call_stack_list (char *name)
 		}
 		p = p->sister;
 	}
-	current_call_stack_list->sister = cob_create_call_stack_list (name);
+	p->sister = cob_create_call_stack_list (name);
 	return;
 }
 

--- a/tests/run.src/misc.at
+++ b/tests/run.src/misc.at
@@ -605,6 +605,71 @@ AT_CHECK([./prog], [0],
 
 AT_CLEANUP
 
+AT_SETUP([CANCEL ALL horizontal program])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+           CALL "call01"
+           END-CALL.
+           CALL "call02"
+           END-CALL.
+           CALL "call03"
+           END-CALL.
+           CANCEL ALL.
+           CALL "call01"
+           END-CALL.
+           CALL "call02"
+           END-CALL.
+           CALL "call03"
+           END-CALL.
+           STOP RUN.
+])
+
+AT_DATA([call01.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      call01.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+           GOBACK.
+])
+
+AT_DATA([call02.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      call02.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       PROCEDURE        DIVISION.
+           GOBACK.
+])
+
+AT_DATA([call03.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      call03.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 X             PIC 9.
+       PROCEDURE        DIVISION.
+           ADD 1 TO X.
+           DISPLAY X
+           END-DISPLAY.
+           EXIT PROGRAM.
+           GOBACK.
+])
+
+AT_CHECK([${COMPILE} -o prog prog.cob])
+AT_CHECK([${COMPILE_MODULE} call01.cob])
+AT_CHECK([${COMPILE_MODULE} call02.cob])
+AT_CHECK([${COMPILE_MODULE} call03.cob])
+AT_CHECK([./prog], [0],
+[1
+1
+])
+
+AT_CLEANUP
+
 AT_SETUP([CALL binary literal parameter/LENGTH OF - so])
 
 AT_CHECK([test $SHREXT != "dll" || exit 77])


### PR DESCRIPTION
親プログラムから3つ以上のプログラムを実行したのち、CANCEL ALLを実施した際に、正常にすべてのプログラムがCANCELされていなかった問題を修正した。

Fixed the problem that not all programs were normally CANCELed when CANCEL ALL was executed after executing 3 or more programs from the parent program.