### PR TITLE
Clear the program stack when executing CANCEL ALL.

### DIFF
--- a/libcob/call.c
+++ b/libcob/call.c
@@ -294,10 +294,10 @@ init_call_stack_list (void)
 static struct call_stack_list *
 cob_create_call_stack_list (char *name)
 {
-	struct call_stack_list *new_list = cob_malloc (sizeof (struct call_stack_list));
+	struct call_stack_list *new_list = malloc (sizeof (struct call_stack_list));
 	memset (new_list, 0, sizeof (struct call_stack_list));
 	new_list->parent = current_call_stack_list;
-	new_list->name = cob_malloc (strlen (name) + 1);
+	new_list->name = malloc (strlen (name) + 1);
 	strcpy (new_list->name, name);
 	current_call_stack_list = new_list;
 	return new_list;
@@ -319,6 +319,8 @@ cob_cancel_call_stack_list (struct call_stack_list *p)
 	if (p->sister) {
 		cob_cancel_call_stack_list (p->sister);
 	}
+	free (p->name);
+	free (p);
 }
 
 const char *
@@ -784,5 +786,6 @@ cob_cancel_all ()
 		return;
 	}
 	cob_cancel_call_stack_list (current_call_stack_list->children);
+	current_call_stack_list->children = NULL;
 	return;
 }

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -297,8 +297,7 @@ cob_create_call_stack_list (char *name)
 	struct call_stack_list *new_list = malloc (sizeof (struct call_stack_list));
 	memset (new_list, 0, sizeof (struct call_stack_list));
 	new_list->parent = current_call_stack_list;
-	new_list->name = malloc (strlen (name) + 1);
-	strcpy (new_list->name, name);
+	new_list->name = strdup (name);
 	current_call_stack_list = new_list;
 	return new_list;
 }


### PR DESCRIPTION
CANCEL ALL実行時に内部で持っているプログラムスタック用のメモリが開放されないため、多くのプログラムを繰り返し実行すると、メモリ使用量とCANCEL処理完了までの時間が増大する不具合が見つかった。

このため、CANCEL ALLが実行されるたびに対象のスタックリストをクリアするように修正した。

----

When CANCEL ALL is executed, the memory used for the program stack is not released internally, so when many programs are executed repeatedly, a problem was found where memory usage and the time required to complete the CANCEL process increased. 

Therefore, we have made a fix so that the target stack list is cleared each time CANCEL ALL is executed.