### PR TITLE
fix(tests): Errors occurring in the new version of GCC

### DIFF
--- a/tests/run.src/misc.at
+++ b/tests/run.src/misc.at
@@ -498,7 +498,8 @@ AT_DATA([caller.cob], [
 
 AT_CHECK([${COMPILE_MODULE} -c callee.cob])
 AT_CHECK([${COMPILE} -c caller.cob])
-AT_CHECK([${COMPILE} -o prog caller.${OBJEXT} callee.${OBJEXT}])
+AT_CHECK([export COB_LDFLAGS="-z muldefs ${COB_LDFLAGS}"; \
+            ${COMPILE} -o prog caller.${OBJEXT} callee.${OBJEXT}])
 AT_CHECK([./prog], [0], [OK])
 
 AT_CLEANUP


### PR DESCRIPTION
* Fixes the issue with multiple definitions of `cob_unifunc` when linking COBOL modules.
* The following error occurred
```
gcc -pipe  -Wl,--export-dynamic -o prog caller.o callee.o  -L/usr/local/lib -lcob -lm -lvbisam -lgmp -lncurses
/usr/bin/ld: callee.o:(.bss+0x0): multiple definition of `cob_unifunc'; caller.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
```

* The details of the cobc renovation will be considered in the future.